### PR TITLE
fix(ci): 修复 sdist 构建中 build 入口点名称错误

### DIFF
--- a/.github/actions/build-wheel-for-publish/action.yml
+++ b/.github/actions/build-wheel-for-publish/action.yml
@@ -94,5 +94,5 @@ runs:
       if: ${{ inputs.build_sdist == 'true' }}
       shell: bash
       run: |
-        pipx run build --sdist --outdir dist .
-        pipx run twine check dist/*
+        uv tool run --from build pyproject-build --sdist --outdir dist .
+        uv tool run --from twine twine check dist/*

--- a/.github/actions/build-wheel-for-publish/action.yml
+++ b/.github/actions/build-wheel-for-publish/action.yml
@@ -94,5 +94,5 @@ runs:
       if: ${{ inputs.build_sdist == 'true' }}
       shell: bash
       run: |
-        uv tool run --from build pyproject-build --sdist --outdir dist .
-        uv tool run --from twine twine check dist/*
+        uv build --sdist --out-dir dist .
+        uvx twine check dist/*


### PR DESCRIPTION
## 问题

`publish_wheel` 工作流中 `Build sdist` 步骤失败：

```
pipx run build --sdist --outdir dist .
An executable named `build` is not provided by package `build`.
The following executables are available:
- pyproject-build
```

## 根因

`build` 包的 console script 入口点名是 `pyproject-build`，不是 `build`。`setup-uv` action 配置后，`pipx` 委托给 `uv` 执行，`uv` 严格检查入口点名称导致失败。

## 修复

将 `.github/actions/build-wheel-for-publish/action.yml` 中 sdist 构建步骤改为：

```diff
- pipx run build --sdist --outdir dist .
- pipx run twine check dist/*
+ uv tool run --from build pyproject-build --sdist --outdir dist .
+ uv tool run --from twine twine check dist/*
```

`twine` 也统一为 `uv tool run` 以保持一致性（twine 入口点名称正确，不受影响）。