### PR TITLE
fix: 移除无效的 PyPI classifier Free Threading :: 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
-  "Programming Language :: Python :: Free Threading :: 2",
 ]
 keywords = ["machine learning", "inference"]
 requires-python = ">=3.8"


### PR DESCRIPTION
## 问题

PyPI publish 返回 400：
```
'Programming Language :: Python :: Free Threading :: 2' is not a valid classifier.
```

该 classifier 不在 PyPI 认可的 trove classifier 列表中。

## 修复

从 `pyproject.toml` 的 classifiers 列表中移除该条目。