### PR TITLE
fix(build): 将 cmake build type 从 RelWithDebInfo 改为 Release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ build.verbose = true
 
 # CMake configuration
 cmake.version = "CMakeLists.txt"
-cmake.build-type = "RelWithDebInfo"
+cmake.build-type = "Release"
 cmake.define.USE_CXX11_ABI = { env = "USE_CXX11_ABI" }
 cmake.define.BUILD_BOTH_ABIS = { env = "BUILD_BOTH_ABIS" }
 cmake.define.SKIP_CMAKE = { env = "SKIP_CMAKE" }


### PR DESCRIPTION
## 问题

PyPI publish 返回 400：`File too large. Limit for project 'omniback' is 100 MB`。

当前 wheel 体积 ~102-105 MB，超过 PyPI 100MB 限制。

## 根因

`pyproject.toml` 中 `cmake.build-type = "RelWithDebInfo"` 在编译时
带 `-g` 调试符号，使 `libomniback.so` 体积膨胀约 2 倍。加上 CI 中
`BUILD_BOTH_ABIS=ON`（CXX11 + CXX03 双份），最终 wheel 超过 100MB。

（sdist 仅 1.1MB，说明不是源文件问题。）

## 修复

将 `cmake.build-type` 从 `RelWithDebInfo` 改为 `Release`
（`-O3 -DNDEBUG`，无 `-g`），预计 wheel 缩小至 ~50MB。