### PR TITLE
fix: avoid torch.utils.cpp_extension attribute access for PyTorch 1.13 compat

### DIFF
--- a/plugins/torchpipe/examples/yolo/yolo_deploy.py
+++ b/plugins/torchpipe/examples/yolo/yolo_deploy.py
@@ -15,7 +15,7 @@ import cv2
 
 # print(omniback.Box)
 
-cpp = torch.utils.cpp_extension.load(
+cpp = cpp_extension.load(
     name="yolo_cpp_extension",
     sources=["yolo.cpp"],
     extra_cflags=["-O3", "-Wall", "-std=c++17"],

--- a/plugins/torchpipe/examples/yolo/yolo_visual.py
+++ b/plugins/torchpipe/examples/yolo/yolo_visual.py
@@ -13,7 +13,7 @@ import omniback
 import cv2
 
 
-cpp = torch.utils.cpp_extension.load(
+cpp = cpp_extension.load(
     name="yolo_cpp_extension",
     sources=["yolo.cpp"],
     extra_cflags=["-O3", "-Wall", "-std=c++17"],

--- a/python/omniback/utils/build_lib.py
+++ b/python/omniback/utils/build_lib.py
@@ -84,14 +84,19 @@ def get_cpp_source(source_dir):
 
 def get_torch_include_paths(build_with_cuda: bool) -> Sequence[str]:
     """Get the include paths for building with torch."""
-    if torch.__version__ >= torch.torch_version.TorchVersion("2.6.0"):
-        return torch.utils.cpp_extension.include_paths(
-            device_type="cuda" if build_with_cuda else "cpu"
-        )
-    else:
-        from torch.utils import cpp_extension
-        # type: ignore[call-arg]
-        return torch.utils.cpp_extension.include_paths(cuda=build_with_cuda)
+    from torch.utils.cpp_extension import include_paths as _include_paths
+
+    # torch.torch_version may not exist in older PyTorch (e.g. 1.13).
+    # Fall back to the cuda= kwarg API when the version check itself fails.
+    try:
+        if torch.__version__ >= torch.torch_version.TorchVersion("2.6.0"):
+            return _include_paths(
+                device_type="cuda" if build_with_cuda else "cpu"
+            )
+    except (AttributeError, ImportError):
+        pass
+
+    return _include_paths(cuda=build_with_cuda)  # type: ignore[call-arg]
 
 def get_cache_dir():
     return str(Path(os.environ.get("OMNIBACK_CACHE_DIR",
@@ -258,24 +263,31 @@ def main() -> None:  # noqa: PLR0912, PLR0915
             cflags.append("-D_GLIBCXX_USE_CXX11_ABI=0")
 
         if not args.no_torch:
+            # Import directly to avoid torch.utils.cpp_extension attribute
+            # access issues on older PyTorch (e.g. 1.13).
+            from torch.utils.cpp_extension import (
+                CUDA_HOME,
+                COMMON_HIP_FLAGS,
+                library_paths,
+            )
+
             if args.build_with_cuda:
                 cflags.append("-DBUILD_WITH_CUDA")
-                if torch.utils.cpp_extension.CUDA_HOME is None:
+                if CUDA_HOME is None:
                     logger.error("CUDA_HOME not found")
             elif args.build_with_rocm:
-                cflags.extend(torch.utils.cpp_extension.COMMON_HIP_FLAGS)
+                cflags.extend(COMMON_HIP_FLAGS)
                 cflags.append("-DBUILD_WITH_ROCM")
             include_paths.extend(get_torch_include_paths(
                 args.build_with_cuda or args.build_with_rocm))
 
-            for lib_dir in torch.utils.cpp_extension.library_paths():
+            for lib_dir in library_paths():
                 if IS_WINDOWS:
                     ldflags.append(f"/LIBPATH:{lib_dir}")
                 else:
                     ldflags.extend(["-L", str(lib_dir)])
 
             import glob
-            from torch.utils.cpp_extension import CUDA_HOME
             if CUDA_HOME is not None:
                 cuda_lib_dir = os.path.join(CUDA_HOME, "lib64")
                 # dirs = glob.glob(os.path.join(CUDA_HOME, "**/*/lib/stubs"))

--- a/python/omniback/utils/build_lib.py
+++ b/python/omniback/utils/build_lib.py
@@ -265,11 +265,12 @@ def main() -> None:  # noqa: PLR0912, PLR0915
         if not args.no_torch:
             # Import directly to avoid torch.utils.cpp_extension attribute
             # access issues on older PyTorch (e.g. 1.13).
-            from torch.utils.cpp_extension import (
-                CUDA_HOME,
-                COMMON_HIP_FLAGS,
-                library_paths,
-            )
+            # COMMON_HIP_FLAGS only exists in ROCm-enabled PyTorch builds.
+            from torch.utils.cpp_extension import CUDA_HOME, library_paths
+            try:
+                from torch.utils.cpp_extension import COMMON_HIP_FLAGS
+            except ImportError:
+                COMMON_HIP_FLAGS = []
 
             if args.build_with_cuda:
                 cflags.append("-DBUILD_WITH_CUDA")


### PR DESCRIPTION
## Summary

PyTorch 1.13 中 `torch.utils.cpp_extension` 的属性访问因懒加载机制失败：
```
AttributeError: module torch.utils has no attribute cpp_extension
```

## Root Cause

PyTorch 1.13 的 `torch.utils` 使用 `__getattr__` 懒加载子模块。`from torch.utils import cpp_extension` 能将模块加载到 `sys.modules`，但不保证在 `torch.utils.__dict__` 中写入属性。后续 `torch.utils.cpp_extension.X` 属性访问因此失败。

这个问题在 May 15 的 feat/jit 合并（`34e91adc`）中引入——else 分支新增了 `from torch.utils import cpp_extension` 试图修复，但下面仍使用 `torch.utils.cpp_extension.include_paths(...)`，修复不完整。

## Changes

### `python/omniback/utils/build_lib.py`
- **`get_torch_include_paths()`**: 改用 `from torch.utils.cpp_extension import include_paths` 直接导入，版本检查加 try/except 保护
- **`main()`**: 将所有 `torch.utils.cpp_extension.CUDA_HOME` / `COMMON_HIP_FLAGS` / `library_paths()` 替换为直接导入的本地变量

### `plugins/torchpipe/examples/yolo/`
- `yolo_deploy.py` / `yolo_visual.py`: `torch.utils.cpp_extension.load()` → `cpp_extension.load()`

## Verification

- 整个代码库 `torch.utils.cpp_extension.` 属性访问已清零
- torch 2.12 实测：新版 `device_type=` API 正常工作
- torch 1.13：走 `cuda=` 旧 API，直接导入规避懒加载问题