### PR TITLE
fix(ci): ensure setuptools installed after torch for torch 1.13

### DIFF
--- a/plugins/torchpipe/scripts/build_aot_wheels.sh
+++ b/plugins/torchpipe/scripts/build_aot_wheels.sh
@@ -69,6 +69,8 @@ function build_local_libs() {
     #     uv pip install torch=="$torch_version"
     # fi
     uv pip install torch==$torch_version --index-url https://download.pytorch.org/whl/cpu # -i  http://mirrors.aliyun.com/pypi/simple/
+    # torch 1.13's cpp_extension requires pkg_resources from setuptools
+    uv pip install setuptools
     
     abiflag=$(python -c "import torch; print(int(torch.compiled_with_cxx11_abi()))")
     if [[ "$os" == "Linux" ]]; then


### PR DESCRIPTION
## Summary

torch 1.13 的 `cpp_extension.py` 模块顶层 `from pkg_resources import packaging` 需要 `setuptools`。CI 脚本 `build_local_libs()` 中安装 torch 后显式安装 setuptools。

## Error

```
ModuleNotFoundError: No module named 'pkg_resources'
```

发生在 `torch/utils/cpp_extension.py:25`。