### PR TITLE
fix(ci): pin setuptools&lt;81 to keep pkg_resources for torch 1.13

### DIFF
--- a/plugins/torchpipe/scripts/build_aot_wheels.sh
+++ b/plugins/torchpipe/scripts/build_aot_wheels.sh
@@ -69,8 +69,9 @@ function build_local_libs() {
     #     uv pip install torch=="$torch_version"
     # fi
     uv pip install torch==$torch_version --index-url https://download.pytorch.org/whl/cpu # -i  http://mirrors.aliyun.com/pypi/simple/
-    # torch 1.13's cpp_extension requires pkg_resources from setuptools
-    uv pip install setuptools
+    # torch 1.13's cpp_extension requires pkg_resources from setuptools;
+    # setuptools>=81 removed pkg_resources entirely, so pin <81.
+    uv pip install "setuptools<81"
     
     abiflag=$(python -c "import torch; print(int(torch.compiled_with_cxx11_abi()))")
     if [[ "$os" == "Linux" ]]; then

--- a/plugins/torchpipe/scripts/build_aot_wheels.sh
+++ b/plugins/torchpipe/scripts/build_aot_wheels.sh
@@ -111,7 +111,8 @@ fi
 
 source "$omniback"/.venv/py3.11/bin/activate
 uv pip install setuptools ninja fire -v
-uv pip install omniback --upgrade --pre
+# Aliyun mirror may lag behind PyPI; install omniback from official index.
+uv pip install omniback --upgrade --pre --index-url https://pypi.org/simple/
 deactivate
 
 # https://pytorch.org/get-started/previous-versions/


### PR DESCRIPTION
## 根因

之前的修复 `#62` 只加了 `uv pip install setuptools`，但 **setuptools >= 81 已彻底移除 `pkg_resources`**。CI 中实际安装了 setuptools 82.0.1，torch 1.13 的 `cpp_extension.py` 内部 `from pkg_resources import packaging` 仍然失败。

## 修复

将 `uv pip install setuptools` 改为 `uv pip install "setuptools<81"`，确保安装的是包含 `pkg_resources` 的版本。

## 另外

CI 中 omniback 版本显示 0.1.24 而非 0.1.25 是因为阿里云镜像延迟，与代码无关。