### PR TITLE
fix: use legacy DLPack API for cross-version PyTorch compatibility

### DIFF
--- a/include/omniback/addons/torch/type_traits.h
+++ b/include/omniback/addons/torch/type_traits.h
@@ -40,14 +40,11 @@ struct TypeTraits<at::Tensor> : public TypeTraitsBase {
   using Self = at::Tensor;
 
   TVM_FFI_INLINE static void MoveToAny(Self&& src, TVMFFIAny* result) {
-#if defined(DLPACK_MAJOR_VERSION) && \
-    (DLPACK_MAJOR_VERSION * 100 + DLPACK_MINOR_VERSION * 10 >= 130)
-    DLManagedTensorVersioned* mid = ::at::toDLPackVersioned(src);
-    tvm::ffi::Tensor te = tvm::ffi::Tensor::FromDLPackVersioned(mid);
-#else
+    // Use legacy DLPack API for maximum compatibility across PyTorch
+    // versions and build flavours. at::toDLPackVersioned is only
+    // available in recent CUDA builds (2.12+), not in CPU wheels.
     DLManagedTensor* mid = ::at::toDLPack(src);
     tvm::ffi::Tensor te = tvm::ffi::Tensor::FromDLPack(mid);
-#endif
     tvm::ffi::TypeTraits<tvm::ffi::Tensor>::MoveToAny(std::move(te), result);
   }
 
@@ -55,16 +52,9 @@ struct TypeTraits<at::Tensor> : public TypeTraitsBase {
       const TVMFFIAny* src) {
     std::optional<tvm::ffi::Tensor> re =
         tvm::ffi::TypeTraits<tvm::ffi::Tensor>::TryCastFromAnyView(src);
-#if defined(DLPACK_MAJOR_VERSION) && \
-    (DLPACK_MAJOR_VERSION * 100 + DLPACK_MINOR_VERSION * 10 >= 130)
-    if (re.has_value()) {
-    return at::fromDLPackVersioned(re.value().ToDLPackVersioned());
-  }
-#else
     if (re.has_value()) {
       return at::fromDLPack(re.value().ToDLPack());
     }
-#endif
     else {
       return std::nullopt;
     }


### PR DESCRIPTION
## 根因

`at::toDLPackVersioned` / `at::fromDLPackVersioned` 仅在 PyTorch 2.12+ CUDA 构建中可用。所有 CPU wheel 和旧版本（1.13 ~ 2.7）均不提供这些符号。但 tvm_ffi 自带了 dlpack.h v1.3（定义 `DLPACK_MAJOR_VERSION=1`），导致预处理器选择了不可用的 versioned 分支。

## 修复

统一使用 legacy DLPack API（`at::toDLPack` / `at::fromDLPack` + `tvm::ffi::Tensor::FromDLPack` / `ToDLPack`），在所有 PyTorch 版本和构建类型中均可用。

## 验证矩阵

| torch 版本 | 构建类型 | 结果 |
|-----------|---------|------|
| 1.13.0 | CPU | ✅ |
| 2.3.0 | CPU | ✅ |
| 2.4.0 | CPU | ✅ |
| 2.5.0 | CPU | ✅ |
| 2.6.0 | CPU | ✅ |
| 2.7.0 | CPU | ✅ |
| 2.12.0 | CUDA | ✅ |