### PR TITLE
fix: guard DLPack versioned API by PyTorch version check

### DIFF
--- a/include/omniback/addons/torch/type_traits.h
+++ b/include/omniback/addons/torch/type_traits.h
@@ -41,7 +41,8 @@ struct TypeTraits<at::Tensor> : public TypeTraitsBase {
 
   TVM_FFI_INLINE static void MoveToAny(Self&& src, TVMFFIAny* result) {
 #if defined(DLPACK_MAJOR_VERSION) && \
-    (DLPACK_MAJOR_VERSION * 100 + DLPACK_MINOR_VERSION * 10 >= 130)
+    (DLPACK_MAJOR_VERSION * 100 + DLPACK_MINOR_VERSION * 10 >= 130) && \
+    (TORCH_VERSION_MAJOR > 2 || (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR >= 12))
     DLManagedTensorVersioned* mid = ::at::toDLPackVersioned(src);
     tvm::ffi::Tensor te = tvm::ffi::Tensor::FromDLPackVersioned(mid);
 #else
@@ -56,7 +57,8 @@ struct TypeTraits<at::Tensor> : public TypeTraitsBase {
     std::optional<tvm::ffi::Tensor> re =
         tvm::ffi::TypeTraits<tvm::ffi::Tensor>::TryCastFromAnyView(src);
 #if defined(DLPACK_MAJOR_VERSION) && \
-    (DLPACK_MAJOR_VERSION * 100 + DLPACK_MINOR_VERSION * 10 >= 130)
+    (DLPACK_MAJOR_VERSION * 100 + DLPACK_MINOR_VERSION * 10 >= 130) && \
+    (TORCH_VERSION_MAJOR > 2 || (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR >= 12))
     if (re.has_value()) {
     return at::fromDLPackVersioned(re.value().ToDLPackVersioned());
   }


### PR DESCRIPTION
## 根因

`at::toDLPackVersioned` / `at::fromDLPackVersioned` 在 PyTorch 2.12 中引入。但 tvm_ffi 自带了 dlpack.h v1.3（定义 `DLPACK_MAJOR_VERSION=1`），仅靠 DLPACK 版本检查会选中 versioned 分支，在旧版 torch 上编译失败。

## 修复

加上 `TORCH_VERSION` 检查：仅在 `TORCH_VERSION_MAJOR > 2 || (MAJOR == 2 && MINOR >= 12)` 时使用 versioned API。

- **torch 1.13 ~ 2.7**：走 legacy 分支（`at::toDLPack` / `at::fromDLPack`）
- **torch 2.12+**：走 versioned 分支（`at::toDLPackVersioned` 等）

## 验证矩阵

| torch 版本 | 构建类型 | 结果 |
|-----------|---------|------|
| 1.13.0 | CPU | ✅ legacy |
| 2.3.0 | CPU | ✅ legacy |
| 2.4.0 | CPU | ✅ legacy |
| 2.5.0 | CPU | ✅ legacy |
| 2.6.0 | CPU | ✅ legacy |
| 2.7.0 | CPU | ✅ legacy |
| 2.12.0 | CUDA | ✅ versioned |