### PR TITLE
fix: guard DLPack versioned API by PyTorch >= 2.9

### DIFF
--- a/include/omniback/addons/torch/type_traits.h
+++ b/include/omniback/addons/torch/type_traits.h
@@ -41,7 +41,8 @@ struct TypeTraits<at::Tensor> : public TypeTraitsBase {
 
   TVM_FFI_INLINE static void MoveToAny(Self&& src, TVMFFIAny* result) {
 #if defined(DLPACK_MAJOR_VERSION) && \
-    (DLPACK_MAJOR_VERSION * 100 + DLPACK_MINOR_VERSION * 10 >= 130)
+    (DLPACK_MAJOR_VERSION * 100 + DLPACK_MINOR_VERSION * 10 >= 130) && \
+    (TORCH_VERSION_MAJOR > 2 || (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR >= 9))
     DLManagedTensorVersioned* mid = ::at::toDLPackVersioned(src);
     tvm::ffi::Tensor te = tvm::ffi::Tensor::FromDLPackVersioned(mid);
 #else
@@ -56,7 +57,8 @@ struct TypeTraits<at::Tensor> : public TypeTraitsBase {
     std::optional<tvm::ffi::Tensor> re =
         tvm::ffi::TypeTraits<tvm::ffi::Tensor>::TryCastFromAnyView(src);
 #if defined(DLPACK_MAJOR_VERSION) && \
-    (DLPACK_MAJOR_VERSION * 100 + DLPACK_MINOR_VERSION * 10 >= 130)
+    (DLPACK_MAJOR_VERSION * 100 + DLPACK_MINOR_VERSION * 10 >= 130) && \
+    (TORCH_VERSION_MAJOR > 2 || (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR >= 9))
     if (re.has_value()) {
     return at::fromDLPackVersioned(re.value().ToDLPackVersioned());
   }


### PR DESCRIPTION
## 根因

`at::toDLPackVersioned` / `at::fromDLPackVersioned` 在 **PyTorch 2.9** 引入（非 2.12）。

二分确认：
- torch 2.8 CPU: ❌ 无此符号
- torch 2.9 CPU: ✅ 有此符号
- torch 2.10 CPU: ✅ 有此符号

## 修复

在 DLPACK 版本检查上加 `TORCH_VERSION_MAJOR > 2 || (MAJOR == 2 && MINOR >= 9)` 条件。

| torch 版本 | 分支 |
|-----------|------|
| 1.13 ~ 2.8 | legacy (`at::toDLPack`) |
| 2.9+ | versioned (`at::toDLPackVersioned`) |