### PR TITLE
chore: bump torchpipe to 0.1.26, align with omniback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ PATH="$PWD/../../.venv/bin:$PATH" FORCE_DOWNLOAD_OPENCV=1 ../../.venv/bin/python
 
 ## 版本号
 - omniback: 由 setuptools-scm 自动生成，`SETUPTOOLS_SCM_PRETEND_VERSION` 覆盖
-- torchpipe: 硬编码在 `plugins/torchpipe/pyproject.toml` 中 `version = "0.1.25"`
+- torchpipe: 硬编码在 `plugins/torchpipe/pyproject.toml` 中 `version = "0.1.26"`
 
 
 ## git remote

--- a/plugins/torchpipe/pyproject.toml
+++ b/plugins/torchpipe/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "torchpipe"
-version = "0.1.25"
+version = "0.1.26"
 
 requires-python = ">=3.8"
 description = "Serving inside Pytorch"
 dependencies = [
     "torch",
-    "omniback>=0.1.25",
+    "omniback>=0.1.26",
     "setuptools",
     "packaging",
     "tqdm",


### PR DESCRIPTION
统一 omniback 和 torchpipe 的 tag。

- torchpipe: 0.1.25 → 0.1.26
- omniback 依赖: >=0.1.25 → >=0.1.26
- 统一使用 tag `t0.1.26`