### PR TITLE
fix(build): include .so files in torchpipe wheel

### DIFF
--- a/plugins/torchpipe/pyproject.toml
+++ b/plugins/torchpipe/pyproject.toml
@@ -18,3 +18,6 @@ dependencies = [
 
 [tool.setuptools]
 packages = ["torchpipe"]
+
+[tool.setuptools.package-data]
+torchpipe = ["lib/*.so"]


### PR DESCRIPTION
## 根因

setuptools 默认不包含 `.so` 文件。`pyproject.toml` 只有 `packages = ["torchpipe"]`，构建的 wheel 中无任何 native library，auditwheel 报 `no ELF executable or shared library file found`。

## 修复

添加 `[tool.setuptools.package-data]`，显式声明 `torchpipe/lib/*.so`。