### PR TITLE
fix: detect missing pkg_resources before importing torch cpp_extension

### DIFF
--- a/python/omniback/utils/build_lib.py
+++ b/python/omniback/utils/build_lib.py
@@ -82,8 +82,25 @@ def get_cpp_source(source_dir):
 
     return source_path
 
+def _check_pkg_resources() -> None:
+    """Ensure pkg_resources is available for torch.utils.cpp_extension.
+
+    torch<2.0 uses pkg_resources (setuptools<81) internally.
+    """
+    try:
+        import pkg_resources  # noqa: F401
+    except ModuleNotFoundError:
+        logger.error(
+            "pkg_resources (setuptools<81) is required for JIT compilation "
+            "with older PyTorch versions (<2.0). Install it with:\n"
+            "  pip install 'setuptools<81'"
+        )
+        raise
+
+
 def get_torch_include_paths(build_with_cuda: bool) -> Sequence[str]:
     """Get the include paths for building with torch."""
+    _check_pkg_resources()
     from torch.utils.cpp_extension import include_paths as _include_paths
 
     # torch.torch_version may not exist in older PyTorch (e.g. 1.13).
@@ -266,6 +283,7 @@ def main() -> None:  # noqa: PLR0912, PLR0915
             # Import directly to avoid torch.utils.cpp_extension attribute
             # access issues on older PyTorch (e.g. 1.13).
             # COMMON_HIP_FLAGS only exists in ROCm-enabled PyTorch builds.
+            _check_pkg_resources()
             from torch.utils.cpp_extension import CUDA_HOME, library_paths
             try:
                 from torch.utils.cpp_extension import COMMON_HIP_FLAGS

--- a/python/omniback/utils/build_lib.py
+++ b/python/omniback/utils/build_lib.py
@@ -86,7 +86,15 @@ def _check_pkg_resources() -> None:
     """Ensure pkg_resources is available for torch.utils.cpp_extension.
 
     torch<2.0 uses pkg_resources (setuptools<81) internally.
+    torch>=2.0 no longer depends on it, so skip the check.
     """
+    # Only needed on PyTorch < 2.0
+    try:
+        if torch.__version__ >= torch.torch_version.TorchVersion("2.0"):
+            return
+    except (AttributeError, ImportError):
+        pass  # old torch without torch_version; likely < 2.0
+
     try:
         import pkg_resources  # noqa: F401
     except ModuleNotFoundError:


### PR DESCRIPTION
## 问题

torch 1.13 CUDA 环境下，torchpipe JIT 编译 CUDA 扩展时调用 `build_lib.py`，其中的 `torch.utils.cpp_extension` 导入触发 `ModuleNotFoundError: No module named 'pkg_resources'`。用户无法得到有意义的错误提示。

## 根因

CI 修复 `#64` 只在 `build_aot_wheels.sh` 中加了 `setuptools<81`，但未处理 torchpipe 用户端 JIT 编译场景。

## 修复

在 `build_lib.py` 中所有 `torch.utils.cpp_extension` 导入前添加 `_check_pkg_resources()` 检查，缺失时给出明确的安装指导。

## 验证

- torch 1.13 CUDA + torchpipe 0.1.26：JIT 编译失败时输出 `pkg_resources (setuptools<81) is required ...`