### PR TITLE
chore: bump omniback & torchpipe to 0.1.27

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ uv pip install --python .venv/bin/python torch cmake ninja  # 基础依赖
 
 ### 编译安装 omniback
 ```bash
-export SETUPTOOLS_SCM_PRETEND_VERSION=0.1.26
+export SETUPTOOLS_SCM_PRETEND_VERSION=0.1.27
 uv pip install --python .venv/bin/python -e .
 ```
 
@@ -46,7 +46,7 @@ PATH="$PWD/../../.venv/bin:$PATH" FORCE_DOWNLOAD_OPENCV=1 ../../.venv/bin/python
 
 ## 版本号
 - omniback: 由 setuptools-scm 自动生成，`SETUPTOOLS_SCM_PRETEND_VERSION` 覆盖
-- torchpipe: 硬编码在 `plugins/torchpipe/pyproject.toml` 中 `version = "0.1.26"`
+- torchpipe: 硬编码在 `plugins/torchpipe/pyproject.toml` 中 `version = "0.1.27"`
 
 
 ## git remote

--- a/plugins/torchpipe/docs/installation.md
+++ b/plugins/torchpipe/docs/installation.md
@@ -58,11 +58,11 @@ uv venv && source .venv/bin/activate
 
 uv pip install --upgrade scikit_build_core fire ninja setuptools-scm setuptools apache-tvm-ffi 
 
-export SETUPTOOLS_SCM_PRETEND_VERSION="0.1.26"
+export SETUPTOOLS_SCM_PRETEND_VERSION="0.1.27"
 
 uv pip install -e . --no-build-isolation -v
 
-python -c "import omniback; assert omniback.__version__ == '0.1.26'"
+python -c "import omniback; assert omniback.__version__ == '0.1.27'"
 
 cd plugins/torchpipe
 

--- a/plugins/torchpipe/docs/installation.md
+++ b/plugins/torchpipe/docs/installation.md
@@ -58,11 +58,11 @@ uv venv && source .venv/bin/activate
 
 uv pip install --upgrade scikit_build_core fire ninja setuptools-scm setuptools apache-tvm-ffi 
 
-export SETUPTOOLS_SCM_PRETEND_VERSION="0.1.27"
+export SETUPTOOLS_SCM_PRETEND_VERSION="..."
 
 uv pip install -e . --no-build-isolation -v
 
-python -c "import omniback; assert omniback.__version__ == '0.1.27'"
+python -c "import omniback; print(omniback.__version__)"
 
 cd plugins/torchpipe
 

--- a/plugins/torchpipe/pyproject.toml
+++ b/plugins/torchpipe/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "torchpipe"
-version = "0.1.26"
+version = "0.1.27"
 
 requires-python = ">=3.8"
 description = "Serving inside Pytorch"
 dependencies = [
     "torch",
-    "omniback>=0.1.26",
+    "omniback>=0.1.27",
     "setuptools",
     "packaging",
     "tqdm",


### PR DESCRIPTION
包含 #71 的 pkg_resources 修复。

- omniback: 0.1.26 → 0.1.27
- torchpipe: 0.1.26 → 0.1.27
- 依赖: omniback>=0.1.27