### PR TITLE
fix: pin setuptools<81 + bump to 0.1.28

### DIFF
--- a/plugins/torchpipe/pyproject.toml
+++ b/plugins/torchpipe/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "torchpipe"
-version = "0.1.27"
+version = "0.1.28"
 
 requires-python = ">=3.8"
 description = "Serving inside Pytorch"
 dependencies = [
     "torch",
     "omniback>=0.1.27",
-    "setuptools",
+    "setuptools<81",
     "packaging",
     "tqdm",
     "requests",


### PR DESCRIPTION
torch<2.0 需要 pkg_resources，setuptools>=81 已移除。把 torchpipe 依赖从 `setuptools` 改为 `setuptools<81`。

合并后 bump 到 0.1.28，后续大版本计划 0.2.0（砍 torch 1.x 支持）。