### PR TITLE
Add encrypted ONNX and TRT cache support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ index-url = "https://mirrors.aliyun.com/pypi/simple/"
 
 ### 创建 venv 并安装依赖
 ```bash
-uv venv --python 3.12
+uv venv --python 3.10
 source .venv/bin/activate  # 可选
 uv pip install --python .venv/bin/python torch cmake ninja  # 基础依赖
 ```

--- a/plugins/torchpipe/pyproject.toml
+++ b/plugins/torchpipe/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "torchpipe"
-version = "0.2.24"
+version = "0.2.25"
 
 requires-python = ">=3.8"
 description = "Serving inside Pytorch"
 dependencies = [
     "torch>=2.2",
-    "omniback>=0.2.24",
+    "omniback==0.2.24",
     "setuptools",
     "packaging",
     "tqdm",

--- a/plugins/torchpipe/scripts/build_aot_wheels.sh
+++ b/plugins/torchpipe/scripts/build_aot_wheels.sh
@@ -121,7 +121,7 @@ done
 
 uv cache clean
 
-torch_versions=("2.7" "2.8" "2.9" "2.10")
+torch_versions=("2.7" "2.8" "2.9")
 for version in "${torch_versions[@]}"; do
     build_local_libs "$version" 3.11
 done

--- a/plugins/torchpipe/tests/test_acc.py
+++ b/plugins/torchpipe/tests/test_acc.py
@@ -30,7 +30,7 @@ class Torch2Trt:
         for k, v in config.items():
             if 'model' in v.keys():
                 v['model'] = onnx_path
-            v['model::cache'] = onnx_path.replace(".onnx", '.trt')+".encrypt"
+            v['model::cache'] = onnx_path.replace(".onnx", '.trt')+".encrypted"
 
         kwargs = omniback.Dict()
         kwargs['config'] = config

--- a/plugins/torchpipe/tests/test_encrypt_utils.py
+++ b/plugins/torchpipe/tests/test_encrypt_utils.py
@@ -180,9 +180,7 @@ def test_cpp_encrypt_roundtrip_uses_sha256_key_derivation(tmp_path):
     input_bytes = bytes((index * 17 + 3) % 256 for index in range(380))
     input_path.write_bytes(input_bytes)
 
-    csrc_dir = Path(
-        "/mnt/data2/zhangshiyang/workspace/torchpipe/plugins/torchpipe/torchpipe/csrc/tensorrt_torch"
-    )
+    csrc_dir = Path(__file__).resolve().parent.parent / "torchpipe" / "csrc" / "tensorrt_torch"
     roundtrip_cpp.write_text(
         f"""
 #include <fstream>

--- a/plugins/torchpipe/tests/test_encrypt_utils.py
+++ b/plugins/torchpipe/tests/test_encrypt_utils.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import shutil
 import subprocess
@@ -9,51 +10,41 @@ from torchpipe.utils import _build_trt as build_trt
 from torchpipe.utils import encrypt as encrypt_utils
 
 
-def test_prepare_secret_key_include_dir_uses_temp_dir_and_writes_header(monkeypatch):
+def test_resolve_compile_time_key_hex_uses_sha256_of_env_secret(monkeypatch):
     monkeypatch.setenv("TORCHPIPE_TENSORRT_SECRET_KEY", "ab-cd 123")
 
-    include_dir, temp_dir = build_trt._prepare_secret_key_include_dir()
-    try:
-        include_path = Path(include_dir)
-        assert include_path.parent == Path(temp_dir)
-
-        header_path = include_path / "torchpipe_tensorrt_secret_key.hpp"
-        assert header_path.exists()
-
-        content = header_path.read_text(encoding="ascii")
-        assert '#define SECRET_KEY tp_ab_cd_123' in content
-    finally:
-        build_trt.shutil.rmtree(temp_dir, ignore_errors=True)
+    assert build_trt._resolve_compile_time_key_hex() == hashlib.sha256(
+        b"ab-cd 123"
+    ).hexdigest()
 
 
-def test_build_trt_cleans_up_temp_secret_dir_on_failure(monkeypatch, tmp_path):
-    temp_dir = tmp_path / "secret-key-dir"
-    include_dir = temp_dir / "include"
-    include_dir.mkdir(parents=True)
-    (include_dir / "torchpipe_tensorrt_secret_key.hpp").write_text(
-        "#define SECRET_KEY tp_test\n",
-        encoding="ascii",
-    )
+def test_build_trt_passes_compiled_key_hex_to_builder(monkeypatch):
+    calls = {}
 
-    monkeypatch.setattr(
-        build_trt,
-        "_prepare_secret_key_include_dir",
-        lambda: (str(include_dir), str(temp_dir)),
-    )
+    monkeypatch.setattr(build_trt, "_resolve_compile_time_key_hex", lambda: "ab" * 32)
     monkeypatch.setattr(build_trt, "need_download_for_jit", lambda: False)
     monkeypatch.setattr(build_trt, "is_system_exists_trt", lambda: True)
     monkeypatch.setattr(build_trt, "can_use_trt_env", lambda: True)
     monkeypatch.setattr(build_trt, "get_trt_include_lib_dir", lambda: (None, None))
+    monkeypatch.setattr(
+        build_trt,
+        "_build_tensorrt_extension",
+        lambda csrc_dir, include_dirs, ldflags, extra_cflags: calls.update(
+            {
+                "csrc_dir": csrc_dir,
+                "include_dirs": include_dirs,
+                "ldflags": ldflags,
+                "extra_cflags": extra_cflags,
+            }
+        ),
+    )
 
-    def fake_run(*args, **kwargs):
-        raise subprocess.CalledProcessError(returncode=1, cmd=args[0])
+    build_trt._build_trt("/tmp/fake-csrc", skip_download=True)
 
-    monkeypatch.setattr(build_trt.subprocess, "run", fake_run)
-
-    with pytest.raises(subprocess.CalledProcessError):
-        build_trt._build_trt("/tmp/fake-csrc", skip_download=True)
-
-    assert not temp_dir.exists()
+    assert calls["csrc_dir"] == "/tmp/fake-csrc"
+    assert calls["include_dirs"] == []
+    assert calls["ldflags"] == ["-lnvinfer", "-lnvonnxparser", "-lnvinfer_plugin"]
+    assert calls["extra_cflags"] == ['-DTORCHPIPE_TENSORRT_KEY_HEX="{}"'.format("ab" * 32)]
 
 
 def test_encrypt_file_calls_exported_c_function(monkeypatch, tmp_path):
@@ -214,7 +205,9 @@ int main() {{
     compile_cmd = [
         gxx,
         "-std=c++17",
-        "-DSECRET_KEY=tp_roundtripcheck",
+        '-DTORCHPIPE_TENSORRT_KEY_HEX="{}"'.format(
+            hashlib.sha256(b"tp_roundtripcheck").hexdigest()
+        ),
         f"-I{csrc_dir}",
         str(roundtrip_cpp),
         str(csrc_dir / "aes.cpp"),

--- a/plugins/torchpipe/tests/test_encrypt_utils.py
+++ b/plugins/torchpipe/tests/test_encrypt_utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 import os
 import shutil
 import subprocess
@@ -45,6 +46,45 @@ def test_build_trt_passes_compiled_key_hex_to_builder(monkeypatch):
     assert calls["include_dirs"] == []
     assert calls["ldflags"] == ["-lnvinfer", "-lnvonnxparser", "-lnvinfer_plugin"]
     assert calls["extra_cflags"] == ['-DTORCHPIPE_TENSORRT_KEY_HEX="{}"'.format("ab" * 32)]
+
+
+def test_build_trt_warns_when_download_not_enabled(monkeypatch, caplog):
+    monkeypatch.delenv("FORCE_DOWNLOAD_TENSORRT", raising=False)
+    monkeypatch.setattr(build_trt, "_resolve_compile_time_key_hex", lambda: "ab" * 32)
+    monkeypatch.setattr(build_trt, "need_download_for_jit", lambda: True)
+    monkeypatch.setattr(
+        build_trt,
+        "_build_tensorrt_extension",
+        lambda *args, **kwargs: pytest.fail("should not build without TensorRT"),
+    )
+
+    with caplog.at_level(logging.INFO):
+        build_trt._build_trt("/tmp/fake-csrc", skip_download=True)
+
+    assert "set FORCE_DOWNLOAD_TENSORRT=1 to download automatically" in caplog.text
+    assert "downloading TensorRT into the cache" not in caplog.text
+
+
+def test_build_trt_logs_download_attempt_when_force_download_enabled(monkeypatch, caplog):
+    monkeypatch.setenv("FORCE_DOWNLOAD_TENSORRT", "1")
+    monkeypatch.setattr(build_trt, "_resolve_compile_time_key_hex", lambda: "ab" * 32)
+    monkeypatch.setattr(build_trt, "need_download_for_jit", lambda: True)
+    monkeypatch.setattr(build_trt, "is_system_exists_trt", lambda: False)
+    monkeypatch.setattr(build_trt, "can_use_trt_env", lambda: False)
+    monkeypatch.setattr(build_trt, "get_trt_include_lib_dir", lambda: (None, None))
+    monkeypatch.setattr(build_trt, "cache_trt_dir", lambda: (None, None))
+    monkeypatch.setattr(
+        build_trt,
+        "_build_tensorrt_extension",
+        lambda *args, **kwargs: pytest.fail("should not build when TensorRT remains unavailable"),
+    )
+
+    with caplog.at_level(logging.INFO):
+        with pytest.raises(RuntimeError, match="download was attempted because FORCE_DOWNLOAD_TENSORRT=1"):
+            build_trt._build_trt("/tmp/fake-csrc", skip_download=True)
+
+    assert "downloading TensorRT into the cache" in caplog.text
+    assert "Set FORCE_DOWNLOAD_TENSORRT=1 to download automatically" not in caplog.text
 
 
 def test_encrypt_file_calls_exported_c_function(monkeypatch, tmp_path):

--- a/plugins/torchpipe/tests/test_encrypt_utils.py
+++ b/plugins/torchpipe/tests/test_encrypt_utils.py
@@ -1,0 +1,235 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from torchpipe.utils import _build_trt as build_trt
+from torchpipe.utils import encrypt as encrypt_utils
+
+
+def test_prepare_secret_key_include_dir_uses_temp_dir_and_writes_header(monkeypatch):
+    monkeypatch.setenv("TORCHPIPE_TENSORRT_SECRET_KEY", "ab-cd 123")
+
+    include_dir, temp_dir = build_trt._prepare_secret_key_include_dir()
+    try:
+        include_path = Path(include_dir)
+        assert include_path.parent == Path(temp_dir)
+
+        header_path = include_path / "torchpipe_tensorrt_secret_key.hpp"
+        assert header_path.exists()
+
+        content = header_path.read_text(encoding="ascii")
+        assert '#define SECRET_KEY tp_ab_cd_123' in content
+    finally:
+        build_trt.shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def test_build_trt_cleans_up_temp_secret_dir_on_failure(monkeypatch, tmp_path):
+    temp_dir = tmp_path / "secret-key-dir"
+    include_dir = temp_dir / "include"
+    include_dir.mkdir(parents=True)
+    (include_dir / "torchpipe_tensorrt_secret_key.hpp").write_text(
+        "#define SECRET_KEY tp_test\n",
+        encoding="ascii",
+    )
+
+    monkeypatch.setattr(
+        build_trt,
+        "_prepare_secret_key_include_dir",
+        lambda: (str(include_dir), str(temp_dir)),
+    )
+    monkeypatch.setattr(build_trt, "need_download_for_jit", lambda: False)
+    monkeypatch.setattr(build_trt, "is_system_exists_trt", lambda: True)
+    monkeypatch.setattr(build_trt, "can_use_trt_env", lambda: True)
+    monkeypatch.setattr(build_trt, "get_trt_include_lib_dir", lambda: (None, None))
+
+    def fake_run(*args, **kwargs):
+        raise subprocess.CalledProcessError(returncode=1, cmd=args[0])
+
+    monkeypatch.setattr(build_trt.subprocess, "run", fake_run)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        build_trt._build_trt("/tmp/fake-csrc", skip_download=True)
+
+    assert not temp_dir.exists()
+
+
+def test_encrypt_file_calls_exported_c_function(monkeypatch, tmp_path):
+    calls = {}
+
+    class FakeEncryptFunc:
+        def __init__(self):
+            self.argtypes = None
+            self.restype = None
+
+        def __call__(self, input_path, output_path, error_message, error_size):
+            calls["input_path"] = input_path
+            calls["output_path"] = output_path
+            calls["error_size"] = error_size
+            error_message.value = b""
+            return 0
+
+    class FakeLib:
+        def __init__(self):
+            self.torchpipe_encrypt_file = FakeEncryptFunc()
+
+    monkeypatch.setattr(
+        encrypt_utils,
+        "_resolve_tensorrt_lib_path",
+        lambda: "/tmp/fake_tensorrt.so",
+    )
+    monkeypatch.setattr(encrypt_utils.ctypes, "CDLL", lambda *args, **kwargs: FakeLib())
+
+    input_path = tmp_path / "model.onnx"
+    output_path = tmp_path / "model.onnx.encrypted"
+    input_path.write_bytes(b"onnx-data")
+
+    encrypt_utils.encrypt_file(str(input_path), str(output_path))
+
+    assert calls["input_path"] == os.fsencode(input_path)
+    assert calls["output_path"] == os.fsencode(output_path)
+    assert calls["error_size"] == 4096
+
+
+def test_encrypt_file_raises_runtime_error_from_native_message(monkeypatch, tmp_path):
+    class FakeEncryptFunc:
+        def __init__(self):
+            self.argtypes = None
+            self.restype = None
+
+        def __call__(self, input_path, output_path, error_message, error_size):
+            error_message.value = b"native failure"
+            return -1
+
+    class FakeLib:
+        def __init__(self):
+            self.torchpipe_encrypt_file = FakeEncryptFunc()
+
+    monkeypatch.setattr(
+        encrypt_utils,
+        "_resolve_tensorrt_lib_path",
+        lambda: "/tmp/fake_tensorrt.so",
+    )
+    monkeypatch.setattr(encrypt_utils.ctypes, "CDLL", lambda *args, **kwargs: FakeLib())
+
+    input_path = tmp_path / "model.onnx"
+    output_path = tmp_path / "model.onnx.encrypted"
+    input_path.write_bytes(b"onnx-data")
+
+    with pytest.raises(RuntimeError, match="native failure"):
+        encrypt_utils.encrypt_file(str(input_path), str(output_path))
+
+
+def test_load_encrypt_symbol_removes_stale_cached_lib(monkeypatch, tmp_path):
+    stale_lib = tmp_path / "torchpipe_tensorrt.so"
+    stale_lib.write_bytes(b"stub")
+
+    class FakeLib:
+        def __getattr__(self, name):
+            raise AttributeError(name)
+
+    monkeypatch.setattr(encrypt_utils.ctypes, "CDLL", lambda *args, **kwargs: FakeLib())
+    monkeypatch.setattr(
+        encrypt_utils.build_lib,
+        "get_cache_lib",
+        lambda name, device, no_torch: str(stale_lib),
+    )
+
+    with pytest.raises(RuntimeError, match="Removed cache; please rerun"):
+        encrypt_utils._load_encrypt_symbol(str(stale_lib))
+
+    assert not stale_lib.exists()
+
+
+def test_main_prints_clear_output_message(monkeypatch, tmp_path, capsys):
+    input_path = tmp_path / "model.onnx"
+    output_path = tmp_path / "model.onnx.encrypted"
+    input_path.write_bytes(b"onnx-data")
+
+    monkeypatch.setattr(
+        encrypt_utils,
+        "encrypt_file",
+        lambda input_file, output_file: None,
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "python -m torchpipe.utils.encrypt",
+            str(input_path),
+            str(output_path),
+        ],
+    )
+
+    encrypt_utils.main()
+
+    captured = capsys.readouterr()
+    assert captured.out.strip() == f"Encrypted file written to: {output_path.resolve()}"
+
+
+def test_cpp_encrypt_roundtrip_uses_sha256_key_derivation(tmp_path):
+    gxx = shutil.which("g++")
+    if gxx is None:
+        pytest.skip("g++ not available")
+
+    input_path = tmp_path / "model.bin"
+    encrypted_path = tmp_path / "model.bin.encrypted"
+    roundtrip_cpp = tmp_path / "roundtrip.cpp"
+    roundtrip_bin = tmp_path / "roundtrip"
+    input_bytes = bytes((index * 17 + 3) % 256 for index in range(380))
+    input_path.write_bytes(input_bytes)
+
+    csrc_dir = Path(
+        "/mnt/data2/zhangshiyang/workspace/torchpipe/plugins/torchpipe/torchpipe/csrc/tensorrt_torch"
+    )
+    roundtrip_cpp.write_text(
+        f"""
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <vector>
+
+#include "encrypt.hpp"
+
+int main() {{
+  std::ifstream input_file("{input_path}", std::ios::binary);
+  std::vector<unsigned char> original(
+      (std::istreambuf_iterator<char>(input_file)),
+      std::istreambuf_iterator<char>());
+
+  torchpipe::encrypt_file_to_file("{input_path}", "{encrypted_path}");
+  auto decrypted = torchpipe::decrypt_file("{encrypted_path}");
+  if (decrypted != original) {{
+    std::cerr << "roundtrip mismatch\\n";
+    return 1;
+  }}
+
+  std::cout << "roundtrip ok\\n";
+  return 0;
+}}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    compile_cmd = [
+        gxx,
+        "-std=c++17",
+        "-DSECRET_KEY=tp_roundtripcheck",
+        f"-I{csrc_dir}",
+        str(roundtrip_cpp),
+        str(csrc_dir / "aes.cpp"),
+        str(csrc_dir / "encrypt.cpp"),
+        "-o",
+        str(roundtrip_bin),
+    ]
+    subprocess.run(compile_cmd, check=True, capture_output=True, text=True)
+    result = subprocess.run(
+        [str(roundtrip_bin)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.strip() == "roundtrip ok"

--- a/plugins/torchpipe/torchpipe/backends/__init__.py
+++ b/plugins/torchpipe/torchpipe/backends/__init__.py
@@ -6,7 +6,6 @@ including TensorRT inference and CUDA stream synchronization.
 """
 
 from .base import BackendProtocol, BackendMeta, register_backend, backend
-from .py_tensorrt import PyTensorrtInferTensor, PyTensorrtEngine
 from .py_sync import PySyncTensor
 
 __all__ = [
@@ -18,3 +17,15 @@ __all__ = [
     "PyTensorrtEngine",
     "PySyncTensor",
 ]
+
+
+def __getattr__(name):
+    if name in {"PyTensorrtInferTensor", "PyTensorrtEngine"}:
+        from .py_tensorrt import PyTensorrtEngine, PyTensorrtInferTensor
+
+        exports = {
+            "PyTensorrtInferTensor": PyTensorrtInferTensor,
+            "PyTensorrtEngine": PyTensorrtEngine,
+        }
+        return exports[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/plugins/torchpipe/torchpipe/backends/py_tensorrt.py
+++ b/plugins/torchpipe/torchpipe/backends/py_tensorrt.py
@@ -29,18 +29,20 @@ from typing import Optional, List, Dict, Any, Tuple, Union, Callable
 logger = logging.getLogger(__name__)
 
 _torch_available = False
+_torch_import_error: Optional[Exception] = None
 try:
     import torch
     _torch_available = True
-except ImportError:
-    logger.error("PyTorch is required for PyTensorrtTensor")
+except ImportError as e:
+    _torch_import_error = e
 
 _tensorrt_available = False
+_tensorrt_import_error: Optional[Exception] = None
 try:
     import tensorrt as trt
     _tensorrt_available = True
-except (ImportError, OSError):
-    logger.error("TensorRT Python bindings are required for PyTensorrtTensor")
+except (ImportError, OSError) as e:
+    _tensorrt_import_error = e
 
 _omniback_available = False
 try:
@@ -92,6 +94,15 @@ TASK_OUTPUT_KEY = "output"
 TASK_ENGINE_KEY = "engine"
 TASK_IO_INFO_KEY = "net_io_infos"
 TASK_INDEX_KEY = "instance_index"
+
+
+def _raise_py_tensorrt_unavailable() -> None:
+    raise TensorRTError(
+        "PyTensorrtTensor requires the TensorRT Python package `tensorrt`, "
+        "but import failed. This does not affect the C++ TensorRT backend or "
+        "`python -m torchpipe.utils.encrypt`.",
+        cause=_tensorrt_import_error,
+    )
 
 
 @dataclass
@@ -221,7 +232,7 @@ class PyTensorrtEngine:
             logger: Optional TensorRT logger
         """
         if not _tensorrt_available:
-            raise TensorRTError("TensorRT not available")
+            _raise_py_tensorrt_unavailable()
         
         if logger is None:
             logger = get_trt_logger()
@@ -258,7 +269,7 @@ class PyTensorrtEngine:
             **kwargs: Additional build options
         """
         if not _tensorrt_available:
-            raise TensorRTError("TensorRT not available")
+            _raise_py_tensorrt_unavailable()
         
         if logger is None:
             logger = get_trt_logger()

--- a/plugins/torchpipe/torchpipe/backends/trt_utils.py
+++ b/plugins/torchpipe/torchpipe/backends/trt_utils.py
@@ -26,18 +26,34 @@ from typing import (
 logger = logging.getLogger(__name__)
 
 _torch_available = False
+_torch_import_error: Optional[Exception] = None
 try:
     import torch
     _torch_available = True
-except ImportError:
-    logger.warning("PyTorch not available")
+except ImportError as e:
+    _torch_import_error = e
 
 _tensorrt_available = False
+_tensorrt_import_error: Optional[Exception] = None
 try:
     import tensorrt as trt
     _tensorrt_available = True
-except (ImportError, OSError):
-    logger.warning("TensorRT Python bindings not available")
+except (ImportError, OSError) as e:
+    _tensorrt_import_error = e
+
+
+def _raise_torch_unavailable(feature: str) -> None:
+    raise TensorRTError(
+        f"{feature} requires PyTorch, but importing `torch` failed.",
+        cause=_torch_import_error,
+    )
+
+
+def _raise_tensorrt_unavailable(feature: str) -> None:
+    raise TensorRTError(
+        f"{feature} requires the TensorRT Python package `tensorrt`, but import failed.",
+        cause=_tensorrt_import_error,
+    )
 
 
 class TensorRTError(Exception):
@@ -220,14 +236,14 @@ TORCH_DTYPE_TO_DATATYPE = {v: k for k, v in DATATYPE_TO_TORCH_DTYPE.items() if v
 def trt_dtype_to_datatype(trt_dtype) -> DataType:
     """Convert TensorRT DataType to our DataType enum."""
     if not _tensorrt_available:
-        raise TensorRTError("TensorRT not available")
+        _raise_tensorrt_unavailable("TensorRT dtype conversion")
     return TRT_DTYPE_TO_DATATYPE.get(trt_dtype, DataType.UNKNOWN)
 
 
 def datatype_to_torch_dtype(dtype: DataType) -> 'torch.dtype':
     """Convert DataType to PyTorch dtype."""
     if not _torch_available:
-        raise TensorRTError("PyTorch not available")
+        _raise_torch_unavailable("Converting TensorRT dtype to torch dtype")
     torch_dtype = DATATYPE_TO_TORCH_DTYPE.get(dtype)
     if torch_dtype is None:
         raise TensorRTError(f"Unsupported DataType: {dtype}")
@@ -237,7 +253,7 @@ def datatype_to_torch_dtype(dtype: DataType) -> 'torch.dtype':
 def torch_dtype_to_datatype(torch_dtype: 'torch.dtype') -> DataType:
     """Convert PyTorch dtype to DataType."""
     if not _torch_available:
-        raise TensorRTError("PyTorch not available")
+        _raise_torch_unavailable("Converting torch dtype to TensorRT dtype")
     return TORCH_DTYPE_TO_DATATYPE.get(torch_dtype, DataType.UNKNOWN)
 
 
@@ -258,7 +274,7 @@ def get_trt_logger() -> 'trt.Logger':
     global _cached_trt_logger
 
     if not _tensorrt_available:
-        raise TensorRTError("TensorRT not available")
+        _raise_tensorrt_unavailable("Creating a TensorRT logger")
 
     if _cached_trt_logger is None:
         _cached_trt_logger = trt.Logger(trt.Logger.WARNING)
@@ -281,7 +297,7 @@ def load_engine_from_file(
         TensorRT CUDA engine
     """
     if not _tensorrt_available:
-        raise TensorRTError("TensorRT not available")
+        _raise_tensorrt_unavailable("Loading a TensorRT engine")
     
     if logger is None:
         logger = get_trt_logger()
@@ -313,7 +329,7 @@ def save_engine_to_file(
         engine_path: Path to save the .trt file
     """
     if not _tensorrt_available:
-        raise TensorRTError("TensorRT not available")
+        _raise_tensorrt_unavailable("Saving a TensorRT engine")
     
     serialized_engine = engine.serialize()
     
@@ -354,7 +370,7 @@ def onnx_to_trt(
         TensorRT CUDA engine
     """
     if not _tensorrt_available:
-        raise TensorRTError("TensorRT not available")
+        _raise_tensorrt_unavailable("Building a TensorRT engine from ONNX")
     
     if logger is None:
         logger = get_trt_logger()
@@ -496,7 +512,7 @@ def get_engine_io_info(
         Tuple of (input_infos, output_infos)
     """
     if not _tensorrt_available:
-        raise TensorRTError("TensorRT not available")
+        _raise_tensorrt_unavailable("Reading TensorRT engine IO info")
     
     input_infos: List[NetIOInfo] = []
     output_infos: List[NetIOInfo] = []
@@ -588,7 +604,7 @@ def get_context_io_info(
         Tuple of (input_infos, output_infos)
     """
     if not _tensorrt_available:
-        raise TensorRTError("TensorRT not available")
+        _raise_tensorrt_unavailable("Reading TensorRT context IO info")
     
     engine = context.engine
     return get_engine_io_info(engine, profile_index)
@@ -609,7 +625,7 @@ def create_context(
         TensorRT execution context
     """
     if not _tensorrt_available:
-        raise TensorRTError("TensorRT not available")
+        _raise_tensorrt_unavailable("Creating a TensorRT execution context")
     
     context = engine.create_execution_context()
     
@@ -709,7 +725,7 @@ class TensorRTAllocator:
             device: CUDA device index
         """
         if not _torch_available:
-            raise TensorRTError("PyTorch not available")
+            _raise_torch_unavailable("TensorRTAllocator")
         
         self._device = device if device is not None else torch.cuda.current_device()
         self._allocations: Dict[int, torch.Tensor] = {}

--- a/plugins/torchpipe/torchpipe/csrc/tensorrt_torch/TensorrtTensor.cpp
+++ b/plugins/torchpipe/torchpipe/csrc/tensorrt_torch/TensorrtTensor.cpp
@@ -4,7 +4,7 @@
 namespace torchpipe {
 
 constexpr auto INIT_STR =
-    "ModelLoadder[(.onnx)Onnx2Tensorrt,(.onnx_buffer)Onnx2Tensorrt,(.trt)LoadTensorrtEngine,(.trt_buffer)LoadTensorrtEngine], "
+    "ModelLoadder[(.onnx)Onnx2Tensorrt,(.onnx.encrypted)Onnx2Tensorrt,(.onnx_buffer)Onnx2Tensorrt,(.trt)LoadTensorrtEngine,(.trt_buffer)LoadTensorrtEngine], "
     "TensorrtInferTensor";
 constexpr auto FORWARD_STR =
     "CatSplit[S[FixTensor,CatTensor],S[ContiguousTensor,"

--- a/plugins/torchpipe/torchpipe/csrc/tensorrt_torch/aes.cpp
+++ b/plugins/torchpipe/torchpipe/csrc/tensorrt_torch/aes.cpp
@@ -54,8 +54,13 @@ unsigned char* AES::EncryptECB(
   KeyExpansion(key, roundKeys);
 
   std::memcpy(out, in, inLen);
-  std::size_t target_index_start = int(inLen / 2.0 * 0.2);
-  std::size_t target_index_end = int(inLen / 2.0 * 0.96);
+  const auto align_to_block = [this](std::size_t value) {
+    return value - value % blockBytesLen;
+  };
+  const std::size_t target_index_start =
+      align_to_block(static_cast<std::size_t>(inLen / 2.0 * 0.2));
+  const std::size_t target_index_end =
+      align_to_block(static_cast<std::size_t>(inLen / 2.0 * 0.96));
   for (std::size_t index = 0; index < target_index_start;
        index += blockBytesLen) {
     if (index % 320 == 0 || (index < 1024 * 1024 && index % 64 == 0) ||
@@ -70,10 +75,10 @@ unsigned char* AES::EncryptECB(
   }
   const std::size_t half_Len = inLen / 2;
   for (std::size_t i = target_index_end; i < half_Len; i += blockBytesLen) {
-    const auto index = target_index_end - i;
-    if (index % 320 == 0 || (index < 1024 * 1024 && index % 64 == 0) ||
-        (index < 1024 * 128 && index % 32 == 0) ||
-        (index < 1024 && index % 8 == 0) || index < 32) {
+    const auto offset = i - target_index_end;
+    if (offset % 320 == 0 || (offset < 1024 * 1024 && offset % 64 == 0) ||
+        (offset < 1024 * 128 && offset % 32 == 0) ||
+        (offset < 1024 && offset % 8 == 0) || offset < 32) {
       EncryptBlock(in + i, out + i, roundKeys);
       EncryptBlock(
           in + inLen - i - blockBytesLen,
@@ -97,8 +102,13 @@ unsigned char* AES::DecryptECB(
   KeyExpansion(key, roundKeys);
 
   std::memcpy(out, in, inLen);
-  std::size_t target_index_start = int(inLen / 2.0 * 0.2);
-  std::size_t target_index_end = int(inLen / 2.0 * 0.96);
+  const auto align_to_block = [this](std::size_t value) {
+    return value - value % blockBytesLen;
+  };
+  const std::size_t target_index_start =
+      align_to_block(static_cast<std::size_t>(inLen / 2.0 * 0.2));
+  const std::size_t target_index_end =
+      align_to_block(static_cast<std::size_t>(inLen / 2.0 * 0.96));
   for (std::size_t index = 0; index < target_index_start;
        index += blockBytesLen) {
     if (index % 320 == 0 || (index < 1024 * 1024 && index % 64 == 0) ||
@@ -113,10 +123,10 @@ unsigned char* AES::DecryptECB(
   }
   const std::size_t half_Len = inLen / 2;
   for (std::size_t i = target_index_end; i < half_Len; i += blockBytesLen) {
-    const auto index = target_index_end - i;
-    if (index % 320 == 0 || (index < 1024 * 1024 && index % 64 == 0) ||
-        (index < 1024 * 128 && index % 32 == 0) ||
-        (index < 1024 && index % 8 == 0) || index < 32) {
+    const auto offset = i - target_index_end;
+    if (offset % 320 == 0 || (offset < 1024 * 1024 && offset % 64 == 0) ||
+        (offset < 1024 * 128 && offset % 32 == 0) ||
+        (offset < 1024 && offset % 8 == 0) || offset < 32) {
       DecryptBlock(in + i, out + i, roundKeys);
       DecryptBlock(
           in + inLen - i - blockBytesLen,

--- a/plugins/torchpipe/torchpipe/csrc/tensorrt_torch/aes.cpp
+++ b/plugins/torchpipe/torchpipe/csrc/tensorrt_torch/aes.cpp
@@ -508,20 +508,20 @@ unsigned char* AES::VectorToArray(std::vector<unsigned char>& a) {
 }
 
 std::vector<unsigned char> AES::EncryptECB(
-    std::vector<unsigned char> in,
-    std::vector<unsigned char> key) {
+    const std::vector<unsigned char>& in,
+    const std::vector<unsigned char>& key) {
   unsigned char* out = EncryptECB(
-      VectorToArray(in), (unsigned int)in.size(), VectorToArray(key));
+      in.data(), (unsigned int)in.size(), key.data());
   std::vector<unsigned char> v = ArrayToVector(out, in.size());
   delete[] out;
   return v;
 }
 
 std::vector<unsigned char> AES::DecryptECB(
-    std::vector<unsigned char> in,
-    std::vector<unsigned char> key) {
+    const std::vector<unsigned char>& in,
+    const std::vector<unsigned char>& key) {
   unsigned char* out = DecryptECB(
-      VectorToArray(in), (unsigned int)in.size(), VectorToArray(key));
+      in.data(), (unsigned int)in.size(), key.data());
   std::vector<unsigned char> v = ArrayToVector(out, (unsigned int)in.size());
   delete[] out;
   return v;

--- a/plugins/torchpipe/torchpipe/csrc/tensorrt_torch/aes.h
+++ b/plugins/torchpipe/torchpipe/csrc/tensorrt_torch/aes.h
@@ -132,12 +132,12 @@ class AES {
       const unsigned char* iv);
 
   std::vector<unsigned char> EncryptECB(
-      std::vector<unsigned char> in,
-      std::vector<unsigned char> key);
+      const std::vector<unsigned char>& in,
+      const std::vector<unsigned char>& key);
 
   std::vector<unsigned char> DecryptECB(
-      std::vector<unsigned char> in,
-      std::vector<unsigned char> key);
+      const std::vector<unsigned char>& in,
+      const std::vector<unsigned char>& key);
 
   std::vector<unsigned char> EncryptCBC(
       std::vector<unsigned char> in,

--- a/plugins/torchpipe/torchpipe/csrc/tensorrt_torch/encrypt.cpp
+++ b/plugins/torchpipe/torchpipe/csrc/tensorrt_torch/encrypt.cpp
@@ -14,6 +14,7 @@
 
 #include <array>
 #include <cassert>
+#include <cctype>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -24,19 +25,12 @@
 
 #include "encrypt.hpp"
 #include "aes.h"
-#if __has_include("torchpipe_tensorrt_secret_key.hpp")
-#include "torchpipe_tensorrt_secret_key.hpp"
-#endif
-#ifndef SECRET_KEY
-#error "SECRET_KEY is not defined. Build torchpipe_tensorrt via torchpipe.utils._build_trt or set TORCHPIPE_TENSORRT_SECRET_KEY."
+#ifndef TORCHPIPE_TENSORRT_KEY_HEX
+#error "TORCHPIPE_TENSORRT_KEY_HEX is not defined. Build torchpipe_tensorrt via torchpipe.utils._build_trt."
 #endif
 
 
 namespace {
-
-
-#define TO_STR_INNER(x) #x
-#define TO_STR(x) TO_STR_INNER(x)
 
 template <typename T, std::size_t N>
 constexpr uint32_t array_sum(T (&array)[N]) {
@@ -232,11 +226,35 @@ Sha256Digest sha256_digest(std::string_view input) {
   return digest;
 }
 
-std::string get_secret_text(const std::string& key) {
-  if (!key.empty()) {
-    return key;
+unsigned char decode_hex_nibble(char value) {
+  if (value >= '0' && value <= '9') {
+    return static_cast<unsigned char>(value - '0');
   }
-  return TO_STR(SECRET_KEY);
+  if (value >= 'a' && value <= 'f') {
+    return static_cast<unsigned char>(10 + value - 'a');
+  }
+  if (value >= 'A' && value <= 'F') {
+    return static_cast<unsigned char>(10 + value - 'A');
+  }
+  throw std::runtime_error("TORCHPIPE_TENSORRT_KEY_HEX contains non-hex characters.");
+}
+
+Sha256Digest parse_key_hex(std::string_view key_hex) {
+  if (key_hex.size() != 64) {
+    throw std::runtime_error("TORCHPIPE_TENSORRT_KEY_HEX must contain 64 hex characters.");
+  }
+  Sha256Digest key_bytes {};
+  for (std::size_t i = 0; i < key_bytes.size(); ++i) {
+    const auto high = decode_hex_nibble(key_hex[i * 2]);
+    const auto low = decode_hex_nibble(key_hex[i * 2 + 1]);
+    key_bytes[i] = static_cast<unsigned char>((high << 4) | low);
+  }
+  return key_bytes;
+}
+
+const Sha256Digest& get_compiled_key_bytes() {
+  static const Sha256Digest key_bytes = parse_key_hex(TORCHPIPE_TENSORRT_KEY_HEX);
+  return key_bytes;
 }
 
 struct KeyMaterial {
@@ -246,8 +264,16 @@ struct KeyMaterial {
 };
 
 KeyMaterial get_primary_key_material(const std::string& key) {
-  const auto secret_text = get_secret_text(key);
-  const auto digest = sha256_digest(secret_text);
+  if (key.empty()) {
+    const auto& key_bytes = get_compiled_key_bytes();
+    return {
+        AESKeyLength::AES_256,
+        std::vector<unsigned char>(key_bytes.begin(), key_bytes.end()),
+        array_sum(key_bytes),
+    };
+  }
+
+  const auto digest = sha256_digest(key);
   return {
       AESKeyLength::AES_256,
       std::vector<unsigned char>(digest.begin(), digest.end()),

--- a/plugins/torchpipe/torchpipe/csrc/tensorrt_torch/encrypt.cpp
+++ b/plugins/torchpipe/torchpipe/csrc/tensorrt_torch/encrypt.cpp
@@ -282,7 +282,9 @@ class OMNI_LOCAL EncryptHelper {
     return std::string(re.begin(), re.end());
   }
 
-  std::vector<unsigned char> decrypt(const std::string& buffer, std::string key) {
+  std::vector<unsigned char> decrypt(
+      const std::vector<unsigned char>& buffer,
+      std::string key) {
     const auto key_material = get_primary_key_material(key);
     return decrypt_with_key_material(buffer, key_material);
   }
@@ -297,12 +299,10 @@ class OMNI_LOCAL EncryptHelper {
     char not_used_post[8];
   };
   std::vector<unsigned char> decrypt_with_key_material(
-      const std::string& buffer,
+      const std::vector<unsigned char>& buffer,
       const KeyMaterial& key_material) {
     AES aes(key_material.key_length);
-    auto result = aes.DecryptECB(
-        std::vector<unsigned char>(buffer.begin(), buffer.end()),
-        key_material.key_bytes);
+    auto result = aes.DecryptECB(buffer, key_material.key_bytes);
     assert(result.size() % 16 == 0);
 
     return get_data(result, get_torchpipe_tag(key_material));
@@ -370,10 +370,9 @@ namespace torchpipe {
  
 OMNI_LOCAL std::vector<unsigned char> decrypt_file(std::string path) {
   const auto encrypted = read_file_binary(path);
-  std::string buffer(encrypted.begin(), encrypted.end());
 
   EncryptHelper decry;
-  std::vector<unsigned char> result = decry.decrypt(buffer, "");
+  std::vector<unsigned char> result = decry.decrypt(encrypted, "");
 
   return result;
 }

--- a/plugins/torchpipe/torchpipe/csrc/tensorrt_torch/encrypt.cpp
+++ b/plugins/torchpipe/torchpipe/csrc/tensorrt_torch/encrypt.cpp
@@ -12,15 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
-#include <fstream>
-
-#include <memory>
+#include <array>
 #include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <memory>
+#include <string_view>
 #include <vector>
 
 #include "encrypt.hpp"
 #include "aes.h"
+#if __has_include("torchpipe_tensorrt_secret_key.hpp")
+#include "torchpipe_tensorrt_secret_key.hpp"
+#endif
+#ifndef SECRET_KEY
+#error "SECRET_KEY is not defined. Build torchpipe_tensorrt via torchpipe.utils._build_trt or set TORCHPIPE_TENSORRT_SECRET_KEY."
+#endif
 
 
 namespace {
@@ -28,17 +37,6 @@ namespace {
 
 #define TO_STR_INNER(x) #x
 #define TO_STR(x) TO_STR_INNER(x)
-
-OMNI_LOCAL std::string get_torchpipe_key() {
-  std::string result = TO_STR(SECRET_KEY);
-
-  while (result.size() < 16) {
-    result += result;
-  }
-  return result;
-}
-
-
 
 template <typename T, std::size_t N>
 constexpr uint32_t array_sum(T (&array)[N]) {
@@ -49,25 +47,222 @@ constexpr uint32_t array_sum(T (&array)[N]) {
   return sum;
 };
 
-const uint32_t array_sum(std::string in) {
+template <typename T, std::size_t N>
+uint32_t array_sum(const std::array<T, N>& array) {
   uint32_t sum = 0;
-  for (std::size_t i = 0; i < in.size(); i++) {
-    sum += in[i];
+  for (const auto value : array) {
+    sum += value;
   }
   return sum;
 };
+
+uint32_t array_sum(const std::string& in) {
+  uint32_t sum = 0;
+  for (std::size_t i = 0; i < in.size(); i++) {
+    sum += static_cast<unsigned char>(in[i]);
+  }
+  return sum;
+};
+
+uint32_t array_sum(const std::vector<unsigned char>& in) {
+  uint32_t sum = 0;
+  for (unsigned char value : in) {
+    sum += value;
+  }
+  return sum;
+};
+
+using Sha256Digest = std::array<unsigned char, 32>;
+
+uint32_t rotr(uint32_t value, uint32_t bits) {
+  return (value >> bits) | (value << (32 - bits));
+}
+
+Sha256Digest sha256_digest(std::string_view input) {
+  static constexpr std::array<uint32_t, 64> kSha256Constants = {
+      0x428a2f98,
+      0x71374491,
+      0xb5c0fbcf,
+      0xe9b5dba5,
+      0x3956c25b,
+      0x59f111f1,
+      0x923f82a4,
+      0xab1c5ed5,
+      0xd807aa98,
+      0x12835b01,
+      0x243185be,
+      0x550c7dc3,
+      0x72be5d74,
+      0x80deb1fe,
+      0x9bdc06a7,
+      0xc19bf174,
+      0xe49b69c1,
+      0xefbe4786,
+      0x0fc19dc6,
+      0x240ca1cc,
+      0x2de92c6f,
+      0x4a7484aa,
+      0x5cb0a9dc,
+      0x76f988da,
+      0x983e5152,
+      0xa831c66d,
+      0xb00327c8,
+      0xbf597fc7,
+      0xc6e00bf3,
+      0xd5a79147,
+      0x06ca6351,
+      0x14292967,
+      0x27b70a85,
+      0x2e1b2138,
+      0x4d2c6dfc,
+      0x53380d13,
+      0x650a7354,
+      0x766a0abb,
+      0x81c2c92e,
+      0x92722c85,
+      0xa2bfe8a1,
+      0xa81a664b,
+      0xc24b8b70,
+      0xc76c51a3,
+      0xd192e819,
+      0xd6990624,
+      0xf40e3585,
+      0x106aa070,
+      0x19a4c116,
+      0x1e376c08,
+      0x2748774c,
+      0x34b0bcb5,
+      0x391c0cb3,
+      0x4ed8aa4a,
+      0x5b9cca4f,
+      0x682e6ff3,
+      0x748f82ee,
+      0x78a5636f,
+      0x84c87814,
+      0x8cc70208,
+      0x90befffa,
+      0xa4506ceb,
+      0xbef9a3f7,
+      0xc67178f2,
+  };
+  std::array<uint32_t, 8> hash = {
+      0x6a09e667,
+      0xbb67ae85,
+      0x3c6ef372,
+      0xa54ff53a,
+      0x510e527f,
+      0x9b05688c,
+      0x1f83d9ab,
+      0x5be0cd19,
+  };
+
+  std::vector<unsigned char> message(input.begin(), input.end());
+  const uint64_t bit_length = static_cast<uint64_t>(message.size()) * 8;
+  message.push_back(0x80);
+  while (message.size() % 64 != 56) {
+    message.push_back(0);
+  }
+  for (int shift = 56; shift >= 0; shift -= 8) {
+    message.push_back(static_cast<unsigned char>((bit_length >> shift) & 0xff));
+  }
+
+  for (std::size_t offset = 0; offset < message.size(); offset += 64) {
+    std::array<uint32_t, 64> words {};
+    for (std::size_t i = 0; i < 16; ++i) {
+      const std::size_t index = offset + i * 4;
+      words[i] = (static_cast<uint32_t>(message[index]) << 24) |
+          (static_cast<uint32_t>(message[index + 1]) << 16) |
+          (static_cast<uint32_t>(message[index + 2]) << 8) |
+          static_cast<uint32_t>(message[index + 3]);
+    }
+    for (std::size_t i = 16; i < words.size(); ++i) {
+      const uint32_t s0 =
+          rotr(words[i - 15], 7) ^ rotr(words[i - 15], 18) ^
+          (words[i - 15] >> 3);
+      const uint32_t s1 =
+          rotr(words[i - 2], 17) ^ rotr(words[i - 2], 19) ^
+          (words[i - 2] >> 10);
+      words[i] = words[i - 16] + s0 + words[i - 7] + s1;
+    }
+
+    uint32_t a = hash[0];
+    uint32_t b = hash[1];
+    uint32_t c = hash[2];
+    uint32_t d = hash[3];
+    uint32_t e = hash[4];
+    uint32_t f = hash[5];
+    uint32_t g = hash[6];
+    uint32_t h = hash[7];
+    for (std::size_t i = 0; i < words.size(); ++i) {
+      const uint32_t sigma1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+      const uint32_t choose = (e & f) ^ ((~e) & g);
+      const uint32_t temp1 =
+          h + sigma1 + choose + kSha256Constants[i] + words[i];
+      const uint32_t sigma0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+      const uint32_t majority = (a & b) ^ (a & c) ^ (b & c);
+      const uint32_t temp2 = sigma0 + majority;
+
+      h = g;
+      g = f;
+      f = e;
+      e = d + temp1;
+      d = c;
+      c = b;
+      b = a;
+      a = temp1 + temp2;
+    }
+
+    hash[0] += a;
+    hash[1] += b;
+    hash[2] += c;
+    hash[3] += d;
+    hash[4] += e;
+    hash[5] += f;
+    hash[6] += g;
+    hash[7] += h;
+  }
+
+  Sha256Digest digest {};
+  for (std::size_t i = 0; i < hash.size(); ++i) {
+    digest[i * 4] = static_cast<unsigned char>((hash[i] >> 24) & 0xff);
+    digest[i * 4 + 1] = static_cast<unsigned char>((hash[i] >> 16) & 0xff);
+    digest[i * 4 + 2] = static_cast<unsigned char>((hash[i] >> 8) & 0xff);
+    digest[i * 4 + 3] = static_cast<unsigned char>(hash[i] & 0xff);
+  }
+  return digest;
+}
+
+std::string get_secret_text(const std::string& key) {
+  if (!key.empty()) {
+    return key;
+  }
+  return TO_STR(SECRET_KEY);
+}
+
+struct KeyMaterial {
+  AESKeyLength key_length;
+  std::vector<unsigned char> key_bytes;
+  uint32_t tag_sum;
+};
+
+KeyMaterial get_primary_key_material(const std::string& key) {
+  const auto secret_text = get_secret_text(key);
+  const auto digest = sha256_digest(secret_text);
+  return {
+      AESKeyLength::AES_256,
+      std::vector<unsigned char>(digest.begin(), digest.end()),
+      array_sum(digest),
+  };
+}
 
 
 
 class OMNI_LOCAL EncryptHelper {
  public:
-  std::string encrypt(const char* buffer,size_t buffer_len,  std::string key) {
-    if (key.empty()) {
-      key = get_torchpipe_key();
-    }
-
+  std::string encrypt(const char* buffer, size_t buffer_len, std::string key) {
+    const auto key_material = get_primary_key_material(key);
     PaddingHead header;
-    header.tag = get_torchpipe_tag();
+    header.tag = get_torchpipe_tag(key_material);
     int total_len =
         4 * 16 - buffer_len % 16 + buffer_len + (sizeof(PaddingHead) % 16) * 16;
     header.data_start = total_len - buffer_len;
@@ -77,27 +272,19 @@ class OMNI_LOCAL EncryptHelper {
     std::vector<unsigned char> tmp_vector(total_len);
     assert(tmp_vector.size() % 16 == 0);
     std::memcpy(tmp_vector.data(), &header, sizeof(PaddingHead));
-    std::memcpy(tmp_vector.data() + header.data_start, buffer, buffer_len);
+    if (buffer_len > 0) {
+      std::memcpy(tmp_vector.data() + header.data_start, buffer, buffer_len);
+    }
 
-    AES aes;
-    auto re = aes.EncryptECB(
-        tmp_vector, std::vector<unsigned char>(key.begin(), key.end()));
+    AES aes(key_material.key_length);
+    auto re = aes.EncryptECB(tmp_vector, key_material.key_bytes);
 
     return std::string(re.begin(), re.end());
   }
 
   std::vector<unsigned char> decrypt(const std::string& buffer, std::string key) {
-    if (key.empty()) {
-      key = get_torchpipe_key();
-    }
-
-    AES aes;
-    auto result = aes.DecryptECB(
-        std::vector<unsigned char>(buffer.begin(), buffer.end()),
-        std::vector<unsigned char>(key.begin(), key.end()));
-    assert(result.size() % 16 == 0);
-
-    return get_data(result);
+    const auto key_material = get_primary_key_material(key);
+    return decrypt_with_key_material(buffer, key_material);
   }
 
  private:
@@ -109,42 +296,94 @@ class OMNI_LOCAL EncryptHelper {
     char time[32] = "2025-11-20";
     char not_used_post[8];
   };
-  std::vector<unsigned char> get_data(const std::vector<unsigned char>& data) {
-    std::vector<unsigned char> result;
+  std::vector<unsigned char> decrypt_with_key_material(
+      const std::string& buffer,
+      const KeyMaterial& key_material) {
+    AES aes(key_material.key_length);
+    auto result = aes.DecryptECB(
+        std::vector<unsigned char>(buffer.begin(), buffer.end()),
+        key_material.key_bytes);
+    assert(result.size() % 16 == 0);
+
+    return get_data(result, get_torchpipe_tag(key_material));
+  }
+
+  std::vector<unsigned char> get_data(
+      const std::vector<unsigned char>& data,
+      uint32_t expected_tag) {
     if (data.size() < sizeof(PaddingHead)) {
       throw std::runtime_error("data.size() < sizeof(head) ");
     }
     const PaddingHead* header =
         reinterpret_cast<const PaddingHead*>(data.data());
-    if (header->tag != get_torchpipe_tag() ||
-        header->data_start + header->data_len != data.size()) {
+    const auto data_start = static_cast<std::size_t>(header->data_start);
+    const auto data_len = static_cast<std::size_t>(header->data_len);
+    const auto data_end = data_start + data_len;
+    if (header->tag != expected_tag || data_start > data.size() ||
+        data_end != data.size()) {
       throw std::runtime_error("DECRYPT: tag or version not match.");
     }
-    auto* p_start = data.data() + header->data_start;
-    result = std::vector<unsigned char>(p_start, p_start + header->data_len);
-    return result;
+    const auto* p_start = data.data() + data_start;
+    return std::vector<unsigned char>(p_start, p_start + data_len);
   }
-  
-  uint32_t get_torchpipe_tag() {
-    return 5432023 + sizeof(PaddingHead)*array_sum(get_torchpipe_key()) ;
+
+  uint32_t get_torchpipe_tag(const KeyMaterial& key_material) {
+    return 5432023 + sizeof(PaddingHead) * key_material.tag_sum;
   }
 };
+
+std::vector<unsigned char> read_file_binary(const std::string& path) {
+  std::ifstream file(path, std::ios::binary);
+  if (!file.good()) {
+    throw std::runtime_error("open failed: " + path);
+  }
+
+  file.seekg(0, std::ios::end);
+  const auto file_size = file.tellg();
+  file.seekg(0, std::ios::beg);
+  if (file_size == std::ifstream::pos_type(-1)) {
+    throw std::runtime_error("tellg failed: " + path);
+  }
+
+  std::vector<unsigned char> buffer(static_cast<size_t>(file_size));
+  if (!buffer.empty()) {
+    file.read(reinterpret_cast<char*>(buffer.data()), buffer.size());
+    if (!file.good()) {
+      throw std::runtime_error("read failed: " + path);
+    }
+  }
+  return buffer;
+}
+
+void write_error_message(
+    char* error_message,
+    size_t error_message_size,
+    const std::string& message) {
+  if (!error_message || error_message_size == 0) {
+    return;
+  }
+  std::snprintf(error_message, error_message_size, "%s", message.c_str());
+}
 } // namespace
 
 namespace torchpipe {
  
 OMNI_LOCAL std::vector<unsigned char> decrypt_file(std::string path) {
-  std::ifstream ff(path);
-  if (!ff.good()) {
-    throw std::runtime_error("open failed: " + path);
-  }
-  std::string buffer(
-      (std::istreambuf_iterator<char>(ff)), std::istreambuf_iterator<char>());
+  const auto encrypted = read_file_binary(path);
+  std::string buffer(encrypted.begin(), encrypted.end());
 
   EncryptHelper decry;
   std::vector<unsigned char> result = decry.decrypt(buffer, "");
 
   return result;
+}
+
+OMNI_LOCAL void encrypt_file_to_file(
+    const std::string& file_path,
+    const std::string& out_file_path) {
+  const auto data = read_file_binary(file_path);
+  encrypt2file(
+      reinterpret_cast<const char*>(data.data()), data.size(), out_file_path);
 }
 
 OMNI_LOCAL void encrypt2file(
@@ -155,10 +394,35 @@ OMNI_LOCAL void encrypt2file(
 
   EncryptHelper decry;
   auto re = decry.encrypt(data, data_len, "");
-  std::ofstream out_ff(out_file_path);
+  std::ofstream out_ff(out_file_path, std::ios::binary);
+  if (!out_ff.good()) {
+    throw std::runtime_error("open failed: " + out_file_path);
+  }
   out_ff << re;
   return;
 
 }
 
 } // namespace torchpipe
+
+extern "C" TORCHPIPE_TENSORRT_EXPORT int torchpipe_encrypt_file(
+    const char* input_path,
+    const char* output_path,
+    char* error_message,
+    size_t error_message_size) {
+  try {
+    if (!input_path || !output_path) {
+      write_error_message(error_message, error_message_size, "input_path or output_path is null");
+      return -1;
+    }
+    torchpipe::encrypt_file_to_file(input_path, output_path);
+    write_error_message(error_message, error_message_size, "");
+    return 0;
+  } catch (const std::exception& e) {
+    write_error_message(error_message, error_message_size, e.what());
+    return -1;
+  } catch (...) {
+    write_error_message(error_message, error_message_size, "unknown error");
+    return -1;
+  }
+}

--- a/plugins/torchpipe/torchpipe/csrc/tensorrt_torch/encrypt.hpp
+++ b/plugins/torchpipe/torchpipe/csrc/tensorrt_torch/encrypt.hpp
@@ -14,20 +14,28 @@
 
 #pragma once
 
+#include <cstddef>
 #include <string>
+#include <vector>
 
 #define OMNI_LOCAL __attribute__((visibility("hidden")))
+#define TORCHPIPE_TENSORRT_EXPORT __attribute__((visibility("default")))
 
 namespace torchpipe {
  
 OMNI_LOCAL std::vector<unsigned char> decrypt_file(std::string path);
-// OMNI_LOCAL void encrypt_file_to_file(
-//     std::string file_path,
-//     std::string out_file_path,
-//     std::string key);
+OMNI_LOCAL void encrypt_file_to_file(
+    const std::string& file_path,
+    const std::string& out_file_path);
 OMNI_LOCAL void encrypt2file(
     const char* data,
     size_t data_len,
     std::string out_file_path);
 
 } // namespace torchpipe
+
+extern "C" TORCHPIPE_TENSORRT_EXPORT int torchpipe_encrypt_file(
+    const char* input_path,
+    const char* output_path,
+    char* error_message,
+    size_t error_message_size);

--- a/plugins/torchpipe/torchpipe/csrc/tensorrt_torch/model.cpp
+++ b/plugins/torchpipe/torchpipe/csrc/tensorrt_torch/model.cpp
@@ -240,7 +240,7 @@ void Onnx2Tensorrt::impl_init(
     auto mem = onnx2trt(params);
     OMNI_ASSERT(mem);
     if (!params.model_cache.empty()) {
-      if (om::str::endswith(params.model_cache, ".enc")) {
+      if (om::str::endswith(params.model_cache, ".enc") || om::str::endswith(params.model_cache, ".encrypted")) {
         torchpipe::encrypt2file(
             (char*)mem->data(), mem->size(), params.model_cache);
       } else {
@@ -266,7 +266,7 @@ void Onnx2Tensorrt::impl_init(
         params.model_cache);
     
     nvinfer1::ICudaEngine* engine_ptr {nullptr};
-    if (om::str::endswith(params.model_cache, ".enc")) {
+    if (om::str::endswith(params.model_cache, ".enc") || om::str::endswith(params.model_cache, ".encrypted")) {
       auto data = torchpipe::decrypt_file(params.model_cache);
       engine_ptr = runtime_->deserializeCudaEngine(data.data(), data.size());
     } else {

--- a/plugins/torchpipe/torchpipe/csrc/tensorrt_torch/tensorrt_helper.cpp
+++ b/plugins/torchpipe/torchpipe/csrc/tensorrt_torch/tensorrt_helper.cpp
@@ -10,6 +10,7 @@
 #include <c10/cuda/CUDAStream.h>
 #include <omniback/extension.hpp>
 #include "NvInferPlugin.h"
+#include "tensorrt_torch/encrypt.hpp"
 #include "tensorrt_torch/tensorrt_helper.hpp"
 
 namespace {
@@ -705,6 +706,17 @@ std::unique_ptr<nvinfer1::IHostMemory> onnx2trt(OnnxParams& params) {
         params.model.data(),
         params.model.size());
     OMNI_ASSERT(b_parsed, "parsed failed for memory buffer");
+  } else if (
+      params.model_type == ".onnx.encrypted" ||
+      params.model_type == "onnx.encrypted" ||
+      om::str::endswith(params.model, ".onnx.encrypted")) {
+    SPDLOG_INFO("parse encrypted onnx {}", params.model);
+    auto decrypted_model = decrypt_file(params.model);
+    OMNI_ASSERT(
+        !decrypted_model.empty(),
+        "decrypted onnx is empty: " + params.model);
+    b_parsed = parser->parse(decrypted_model.data(), decrypted_model.size());
+    OMNI_ASSERT(b_parsed, "parsed failed for encrypted onnx " + params.model);
   } else {
     SPDLOG_INFO("parse {}", params.model);
     b_parsed = parser->parseFromFile(

--- a/plugins/torchpipe/torchpipe/utils/_build_trt.py
+++ b/plugins/torchpipe/torchpipe/utils/_build_trt.py
@@ -320,28 +320,30 @@ def _build_trt(csrc_dir, skip_download=True):
 
     key_hex = _resolve_compile_time_key_hex()
     extra_cflags = [f'-DTORCHPIPE_TENSORRT_KEY_HEX="{key_hex}"']
+    force_download_tensorrt = os.environ.get("FORCE_DOWNLOAD_TENSORRT", "0")
     if skip_download and need_download_for_jit():
-        logger.warning(
-                "TensorRT not found. Checked:\n"
-                "  1. Environment variables TENSORRT_INCLUDE and TENSORRT_LIB,\n"
-                "  2. Standard system library paths\n"
-                "  3. Cache directory\n"
-                "\n"
-                "Please either:\n"
-                "  - Set TENSORRT_INCLUDE (e.g., /path/to/TensorRT/include) and TENSORRT_LIB (e.g., /path/to/TensorRT/lib), or\n"
-                "  - Set FORCE_DOWNLOAD_TENSORRT=1 to download automatically, or\n"
-                "  - Set TORCHPIPE_SKIP_TENSORRT=1 to skip TensorRT support entirely.\n"
-                "You may also need to set LD_LIBRARY_PATH if not installed in a standard system path.\n"
+        if force_download_tensorrt == "0":
+            logger.warning(
+                "TensorRT not found in environment variables, system library paths, or cache.\n"
+                "Set TENSORRT_INCLUDE/TENSORRT_LIB, set FORCE_DOWNLOAD_TENSORRT=1 to download automatically,\n"
+                "or set TORCHPIPE_SKIP_TENSORRT=1 to skip TensorRT support."
             )
-        FORCE_DOWNLOAD_TENSORRT = os.environ.get("FORCE_DOWNLOAD_TENSORRT", "0")
-        if FORCE_DOWNLOAD_TENSORRT == "0":
             return
+        logger.info(
+            "TensorRT not found locally; FORCE_DOWNLOAD_TENSORRT=1, downloading TensorRT into the cache."
+        )
 
     if not is_system_exists_trt() and not can_use_trt_env():
         trt_inc, trt_lib = get_trt_include_lib_dir()
         if trt_inc is None:
             trt_inc, trt_lib = cache_trt_dir()
         if trt_inc is None:
+            if force_download_tensorrt != "0":
+                raise RuntimeError(
+                    "TensorRT download was attempted because FORCE_DOWNLOAD_TENSORRT=1, "
+                    "but TensorRT is still unavailable. Set TENSORRT_INCLUDE/TENSORRT_LIB "
+                    "manually or inspect the download/cache state."
+                )
             raise RuntimeError(
                 "TensorRT not found. Please specify its location using the "
                 "TENSORRT_INCLUDE and TENSORRT_LIB environment variables, "

--- a/plugins/torchpipe/torchpipe/utils/_build_trt.py
+++ b/plugins/torchpipe/torchpipe/utils/_build_trt.py
@@ -80,6 +80,16 @@ def _build_tensorrt_extension(
                 link_flags.extend(["-L", str(lib_dir)])
 
         if CUDA_HOME is None:
+            if hasattr(torch, "version") and getattr(torch.version, "cuda", None):
+                torch_dir = os.path.dirname(torch.__file__)
+                if os.path.exists(os.path.join(torch_dir, "lib")):
+                    CUDA_HOME = torch_dir
+                    os.environ["CUDA_HOME"] = CUDA_HOME
+                    logger.warning(
+                        "CUDA_HOME not found. Falling back to PyTorch's internal CUDA path: %s",
+                        CUDA_HOME,
+                    )
+        if CUDA_HOME is None:
             logger.error("CUDA_HOME not found")
         else:
             cuda_lib_dir = os.path.join(

--- a/plugins/torchpipe/torchpipe/utils/_build_trt.py
+++ b/plugins/torchpipe/torchpipe/utils/_build_trt.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import logging
 import os
+import secrets
 import shutil
 import subprocess
 import sys
+import tempfile
 from typing import Optional, Tuple
 
 import torch
@@ -17,6 +19,31 @@ from ._cache_setting import get_cache_dir
 logger = logging.getLogger(__name__)
 
 _cuda_version = int(torch.version.cuda.split('.')[0])
+
+
+def _prepare_secret_key_include_dir() -> Tuple[str, str]:
+    """Generate a compile-time secret key header for TensorRT encryption."""
+    temp_dir = tempfile.mkdtemp(prefix="torchpipe-tensorrt-key-")
+    include_dir = os.path.join(temp_dir, "include")
+    os.makedirs(include_dir, exist_ok=True)
+
+    secret_key = os.environ.get("TORCHPIPE_TENSORRT_SECRET_KEY")
+    if not secret_key:
+        secret_key = f"tp_{secrets.token_hex(16)}"
+    else:
+        secret_key = "tp_" + "".join(
+            ch if ch.isalnum() else "_" for ch in secret_key.strip()
+        )
+
+    header_path = os.path.join(include_dir, "torchpipe_tensorrt_secret_key.hpp")
+    with open(header_path, "w", encoding="ascii") as f:
+        f.write(
+            "#pragma once\n"
+            f"#define SECRET_KEY {secret_key}\n"
+        )
+
+    logger.info("Prepared temporary TensorRT encryption key header at %s", header_path)
+    return include_dir, temp_dir
 
 def is_system_exists_trt() -> bool:
     """Check if TensorRT is available in system paths."""
@@ -205,60 +232,40 @@ def _build_trt(csrc_dir, skip_download=True):
         logger.info("TORCHPIPE_SKIP_TENSORRT=1, skipping TensorRT build")
         return
 
-    if skip_download and need_download_for_jit():
-        logger.warning(
-                "TensorRT not found. Checked:\n"
-                "  1. Environment variables TENSORRT_INCLUDE and TENSORRT_LIB,\n"
-                "  2. Standard system library paths\n"
-                "  3. Cache directory\n"
-                "\n"
-                "Please either:\n"
-                "  - Set TENSORRT_INCLUDE (e.g., /path/to/TensorRT/include) and TENSORRT_LIB (e.g., /path/to/TensorRT/lib), or\n"
-                "  - Set FORCE_DOWNLOAD_TENSORRT=1 to download automatically, or\n"
-                "  - Set TORCHPIPE_SKIP_TENSORRT=1 to skip TensorRT support entirely.\n"
-                "You may also need to set LD_LIBRARY_PATH if not installed in a standard system path.\n"
-            )
-        FORCE_DOWNLOAD_TENSORRT = os.environ.get("FORCE_DOWNLOAD_TENSORRT", "0")
-        if FORCE_DOWNLOAD_TENSORRT == "0":
-            return
+    secret_key_include_dir, secret_key_temp_dir = _prepare_secret_key_include_dir()
+    try:
+        if skip_download and need_download_for_jit():
+            logger.warning(
+                    "TensorRT not found. Checked:\n"
+                    "  1. Environment variables TENSORRT_INCLUDE and TENSORRT_LIB,\n"
+                    "  2. Standard system library paths\n"
+                    "  3. Cache directory\n"
+                    "\n"
+                    "Please either:\n"
+                    "  - Set TENSORRT_INCLUDE (e.g., /path/to/TensorRT/include) and TENSORRT_LIB (e.g., /path/to/TensorRT/lib), or\n"
+                    "  - Set FORCE_DOWNLOAD_TENSORRT=1 to download automatically, or\n"
+                    "  - Set TORCHPIPE_SKIP_TENSORRT=1 to skip TensorRT support entirely.\n"
+                    "You may also need to set LD_LIBRARY_PATH if not installed in a standard system path.\n"
+                )
+            FORCE_DOWNLOAD_TENSORRT = os.environ.get("FORCE_DOWNLOAD_TENSORRT", "0")
+            if FORCE_DOWNLOAD_TENSORRT == "0":
+                return
 
-    # python -m omniback.utils.build_lib --source-dirs csrc/tensorrt_torch/ --include-dirs=csrc/ --build-with-cuda --ldflags="-lnvinfer -lnvonnxparser  -lnvinfer_plugin" --name torchpipe_tensorrt
+        # python -m omniback.utils.build_lib --source-dirs csrc/tensorrt_torch/ --include-dirs=csrc/ --build-with-cuda --ldflags="-lnvinfer -lnvonnxparser  -lnvinfer_plugin" --name torchpipe_tensorrt
 
-    if not is_system_exists_trt() and not can_use_trt_env():
-        trt_inc, trt_lib = get_trt_include_lib_dir()
-        if trt_inc is None:
-            trt_inc, trt_lib = cache_trt_dir()
-        if trt_inc is None:
-            raise RuntimeError(
-                "TensorRT not found. Please specify its location using the "
-                "TENSORRT_INCLUDE and TENSORRT_LIB environment variables, "
-                "or set FORCE_DOWNLOAD_TENSORRT=1 to automatically download."
-            )
-        os.environ["LD_LIBRARY_PATH"] = f"{trt_lib}:" + \
-            os.environ.get("LD_LIBRARY_PATH", "")
+        if not is_system_exists_trt() and not can_use_trt_env():
+            trt_inc, trt_lib = get_trt_include_lib_dir()
+            if trt_inc is None:
+                trt_inc, trt_lib = cache_trt_dir()
+            if trt_inc is None:
+                raise RuntimeError(
+                    "TensorRT not found. Please specify its location using the "
+                    "TENSORRT_INCLUDE and TENSORRT_LIB environment variables, "
+                    "or set FORCE_DOWNLOAD_TENSORRT=1 to automatically download."
+                )
+            os.environ["LD_LIBRARY_PATH"] = f"{trt_lib}:" + \
+                os.environ.get("LD_LIBRARY_PATH", "")
 
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "omniback.utils.build_lib",
-                "--source-dirs",
-                os.path.join(csrc_dir, "csrc/tensorrt_torch/"),
-                "--include-dirs",
-                os.path.join(csrc_dir, "csrc/"),
-                f"{trt_inc}",
-                "--build-with-cuda",
-                # f"--ldflags=-L{trt_lib} -lnvinfer -lnvonnxparser  -lnvinfer_plugin",
-                f"--ldflags=-L{trt_lib} -Wl,-rpath,{trt_lib} -lnvinfer -lnvonnxparser -lnvinfer_plugin",
-                "--name",
-                "torchpipe_tensorrt"
-            ],
-            check=True,
-            env={**os.environ, "EXAMPLE_ENV": "1"},
-        )
-    else:
-        trt_inc, trt_lib = get_trt_include_lib_dir()
-        if trt_inc and trt_lib:
             subprocess.run(
                 [
                     sys.executable,
@@ -268,8 +275,10 @@ def _build_trt(csrc_dir, skip_download=True):
                     os.path.join(csrc_dir, "csrc/tensorrt_torch/"),
                     "--include-dirs",
                     os.path.join(csrc_dir, "csrc/"),
-                    trt_inc,
+                    secret_key_include_dir,
+                    f"{trt_inc}",
                     "--build-with-cuda",
+                    # f"--ldflags=-L{trt_lib} -lnvinfer -lnvonnxparser  -lnvinfer_plugin",
                     f"--ldflags=-L{trt_lib} -Wl,-rpath,{trt_lib} -lnvinfer -lnvonnxparser -lnvinfer_plugin",
                     "--name",
                     "torchpipe_tensorrt"
@@ -278,20 +287,45 @@ def _build_trt(csrc_dir, skip_download=True):
                 env={**os.environ, "EXAMPLE_ENV": "1"},
             )
         else:
-            subprocess.run(
-                [
-                    sys.executable,
-                    "-m",
-                    "omniback.utils.build_lib",
-                    "--source-dirs",
-                    os.path.join(csrc_dir, "csrc/tensorrt_torch/"),
-                    "--include-dirs",
-                    os.path.join(csrc_dir, "csrc/"),
-                    "--build-with-cuda",
-                    f"--ldflags=-lnvinfer -lnvonnxparser -lnvinfer_plugin",
-                    "--name",
-                    "torchpipe_tensorrt"
-                ],
-                check=True,
-                env={**os.environ, "EXAMPLE_ENV": "1"},
-            )
+            trt_inc, trt_lib = get_trt_include_lib_dir()
+            if trt_inc and trt_lib:
+                subprocess.run(
+                    [
+                        sys.executable,
+                        "-m",
+                        "omniback.utils.build_lib",
+                        "--source-dirs",
+                        os.path.join(csrc_dir, "csrc/tensorrt_torch/"),
+                        "--include-dirs",
+                        os.path.join(csrc_dir, "csrc/"),
+                        secret_key_include_dir,
+                        trt_inc,
+                        "--build-with-cuda",
+                        f"--ldflags=-L{trt_lib} -Wl,-rpath,{trt_lib} -lnvinfer -lnvonnxparser -lnvinfer_plugin",
+                        "--name",
+                        "torchpipe_tensorrt"
+                    ],
+                    check=True,
+                    env={**os.environ, "EXAMPLE_ENV": "1"},
+                )
+            else:
+                subprocess.run(
+                    [
+                        sys.executable,
+                        "-m",
+                        "omniback.utils.build_lib",
+                        "--source-dirs",
+                        os.path.join(csrc_dir, "csrc/tensorrt_torch/"),
+                        "--include-dirs",
+                        os.path.join(csrc_dir, "csrc/"),
+                        secret_key_include_dir,
+                        "--build-with-cuda",
+                        f"--ldflags=-lnvinfer -lnvonnxparser -lnvinfer_plugin",
+                        "--name",
+                        "torchpipe_tensorrt"
+                    ],
+                    check=True,
+                    env={**os.environ, "EXAMPLE_ENV": "1"},
+                )
+    finally:
+        shutil.rmtree(secret_key_temp_dir, ignore_errors=True)

--- a/plugins/torchpipe/torchpipe/utils/_build_trt.py
+++ b/plugins/torchpipe/torchpipe/utils/_build_trt.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import secrets
@@ -9,10 +10,12 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from pathlib import Path
 from typing import Optional, Tuple
 
 import torch
 
+from omniback.utils import build_lib as omniback_build_lib
 from omniback.utils.system_path import system_include_dirs, system_library_dirs
 from ._cache_setting import get_cache_dir
 
@@ -21,29 +24,102 @@ logger = logging.getLogger(__name__)
 _cuda_version = int(torch.version.cuda.split('.')[0])
 
 
-def _prepare_secret_key_include_dir() -> Tuple[str, str]:
-    """Generate a compile-time secret key header for TensorRT encryption."""
-    temp_dir = tempfile.mkdtemp(prefix="torchpipe-tensorrt-key-")
-    include_dir = os.path.join(temp_dir, "include")
-    os.makedirs(include_dir, exist_ok=True)
-
+def _resolve_compile_time_key_hex() -> str:
+    """Return a deterministic 32-byte key for TensorRT encryption."""
     secret_key = os.environ.get("TORCHPIPE_TENSORRT_SECRET_KEY")
     if not secret_key:
-        secret_key = f"tp_{secrets.token_hex(16)}"
-    else:
-        secret_key = "tp_" + "".join(
-            ch if ch.isalnum() else "_" for ch in secret_key.strip()
-        )
+        return secrets.token_hex(32)
+    return hashlib.sha256(secret_key.encode("utf-8")).hexdigest()
 
-    header_path = os.path.join(include_dir, "torchpipe_tensorrt_secret_key.hpp")
-    with open(header_path, "w", encoding="ascii") as f:
-        f.write(
-            "#pragma once\n"
-            f"#define SECRET_KEY {secret_key}\n"
-        )
 
-    logger.info("Prepared temporary TensorRT encryption key header at %s", header_path)
-    return include_dir, temp_dir
+def _build_tensorrt_extension(
+        csrc_dir: str,
+        include_dirs: list[str],
+        ldflags: list[str],
+        extra_cflags: list[str]) -> None:
+    """Build the TensorRT extension without emitting a temporary header file."""
+    os.environ["TVM_FFI_DISABLE_TORCH_C_DLPACK"] = "1"
+    from tvm_ffi.cpp.extension import build
+    from tvm_ffi.utils.lockfile import FileLock
+    from torch.utils.cpp_extension import CUDA_HOME, library_paths
+    import omniback as om
+    from omniback import get_include_dirs
+
+    abiflag = "1" if torch.compiled_with_cxx11_abi() else "0"
+    libname = omniback_build_lib.get_cache_name("torchpipe_tensorrt", "cuda", False, abiflag)
+    tmp_libname = libname + ".tmp"
+    suffix = ".dll" if omniback_build_lib.IS_WINDOWS else ".so"
+    output_dir = Path(omniback_build_lib.get_cache_dir()).expanduser()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    final_path = output_dir / f"{libname}{suffix}"
+
+    with FileLock(str(output_dir / f"{libname}.lock")):
+        if final_path.exists():
+            return
+
+        source_dirs = [Path(csrc_dir).expanduser() / "csrc" / "tensorrt_torch"]
+        source_path = omniback_build_lib.get_cpp_source([str(path) for path in source_dirs])
+
+        include_paths = [str((Path(csrc_dir).expanduser() / "csrc").resolve())]
+        include_paths.extend(str(Path(path).expanduser().resolve()) for path in include_dirs)
+
+        cflags = [
+            f"-D_GLIBCXX_USE_CXX11_ABI={abiflag}",
+            "-DBUILD_WITH_CUDA",
+            *extra_cflags,
+        ]
+        link_flags = list(ldflags)
+
+        omniback_build_lib._check_pkg_resources()
+        include_paths.extend(omniback_build_lib.get_torch_include_paths(True))
+
+        for lib_dir in library_paths():
+            if omniback_build_lib.IS_WINDOWS:
+                link_flags.append(f"/LIBPATH:{lib_dir}")
+            else:
+                link_flags.extend(["-L", str(lib_dir)])
+
+        if CUDA_HOME is None:
+            logger.error("CUDA_HOME not found")
+        else:
+            cuda_lib_dir = os.path.join(
+                CUDA_HOME,
+                "lib64" if os.path.exists(os.path.join(CUDA_HOME, "lib64")) else "lib",
+            )
+            if omniback_build_lib.IS_WINDOWS:
+                link_flags.append(f"/LIBPATH:{cuda_lib_dir}")
+            else:
+                link_flags.extend(["-L", str(cuda_lib_dir)])
+
+        if omniback_build_lib.IS_WINDOWS:
+            link_flags.extend(["c10.lib", "torch.lib", "torch_cpu.lib", "torch_cuda.lib", "c10_cuda.lib"])
+        else:
+            link_flags.extend(["-lc10", "-ltorch", "-ltorch_cpu", "-ltorch_cuda", "-lc10_cuda"])
+
+        om_lib = om.libinfo.find_libomniback()
+        link_flags.append(f"-L{os.path.dirname(om_lib)}")
+        om_lib_name = os.path.splitext(os.path.basename(om_lib))[0].strip("lib")
+        if om_lib_name.startswith("lib"):
+            om_lib_name = om_lib_name[3:]
+        link_flags.append(f"-l{om_lib_name}")
+
+        include_paths += get_include_dirs()
+        include_paths = omniback_build_lib.unique_paths([str(path) for path in include_paths])
+
+        with tempfile.TemporaryDirectory(prefix="omniback-torch") as build_dir:
+            result_lib = build(
+                name=tmp_libname,
+                cpp_files=[str(path) for path in source_path],
+                extra_cflags=cflags,
+                extra_ldflags=link_flags,
+                extra_include_paths=include_paths,
+                build_directory=build_dir,
+            )
+            shutil.move(
+                str(result_lib),
+                str(final_path),
+            )
+            print(f"saved to {final_path}")
 
 def is_system_exists_trt() -> bool:
     """Check if TensorRT is available in system paths."""
@@ -232,100 +308,56 @@ def _build_trt(csrc_dir, skip_download=True):
         logger.info("TORCHPIPE_SKIP_TENSORRT=1, skipping TensorRT build")
         return
 
-    secret_key_include_dir, secret_key_temp_dir = _prepare_secret_key_include_dir()
-    try:
-        if skip_download and need_download_for_jit():
-            logger.warning(
-                    "TensorRT not found. Checked:\n"
-                    "  1. Environment variables TENSORRT_INCLUDE and TENSORRT_LIB,\n"
-                    "  2. Standard system library paths\n"
-                    "  3. Cache directory\n"
-                    "\n"
-                    "Please either:\n"
-                    "  - Set TENSORRT_INCLUDE (e.g., /path/to/TensorRT/include) and TENSORRT_LIB (e.g., /path/to/TensorRT/lib), or\n"
-                    "  - Set FORCE_DOWNLOAD_TENSORRT=1 to download automatically, or\n"
-                    "  - Set TORCHPIPE_SKIP_TENSORRT=1 to skip TensorRT support entirely.\n"
-                    "You may also need to set LD_LIBRARY_PATH if not installed in a standard system path.\n"
-                )
-            FORCE_DOWNLOAD_TENSORRT = os.environ.get("FORCE_DOWNLOAD_TENSORRT", "0")
-            if FORCE_DOWNLOAD_TENSORRT == "0":
-                return
+    key_hex = _resolve_compile_time_key_hex()
+    extra_cflags = [f'-DTORCHPIPE_TENSORRT_KEY_HEX="{key_hex}"']
+    if skip_download and need_download_for_jit():
+        logger.warning(
+                "TensorRT not found. Checked:\n"
+                "  1. Environment variables TENSORRT_INCLUDE and TENSORRT_LIB,\n"
+                "  2. Standard system library paths\n"
+                "  3. Cache directory\n"
+                "\n"
+                "Please either:\n"
+                "  - Set TENSORRT_INCLUDE (e.g., /path/to/TensorRT/include) and TENSORRT_LIB (e.g., /path/to/TensorRT/lib), or\n"
+                "  - Set FORCE_DOWNLOAD_TENSORRT=1 to download automatically, or\n"
+                "  - Set TORCHPIPE_SKIP_TENSORRT=1 to skip TensorRT support entirely.\n"
+                "You may also need to set LD_LIBRARY_PATH if not installed in a standard system path.\n"
+            )
+        FORCE_DOWNLOAD_TENSORRT = os.environ.get("FORCE_DOWNLOAD_TENSORRT", "0")
+        if FORCE_DOWNLOAD_TENSORRT == "0":
+            return
 
-        # python -m omniback.utils.build_lib --source-dirs csrc/tensorrt_torch/ --include-dirs=csrc/ --build-with-cuda --ldflags="-lnvinfer -lnvonnxparser  -lnvinfer_plugin" --name torchpipe_tensorrt
-
-        if not is_system_exists_trt() and not can_use_trt_env():
-            trt_inc, trt_lib = get_trt_include_lib_dir()
-            if trt_inc is None:
-                trt_inc, trt_lib = cache_trt_dir()
-            if trt_inc is None:
-                raise RuntimeError(
-                    "TensorRT not found. Please specify its location using the "
-                    "TENSORRT_INCLUDE and TENSORRT_LIB environment variables, "
-                    "or set FORCE_DOWNLOAD_TENSORRT=1 to automatically download."
-                )
-            os.environ["LD_LIBRARY_PATH"] = f"{trt_lib}:" + \
-                os.environ.get("LD_LIBRARY_PATH", "")
-
-            subprocess.run(
-                [
-                    sys.executable,
-                    "-m",
-                    "omniback.utils.build_lib",
-                    "--source-dirs",
-                    os.path.join(csrc_dir, "csrc/tensorrt_torch/"),
-                    "--include-dirs",
-                    os.path.join(csrc_dir, "csrc/"),
-                    secret_key_include_dir,
-                    f"{trt_inc}",
-                    "--build-with-cuda",
-                    # f"--ldflags=-L{trt_lib} -lnvinfer -lnvonnxparser  -lnvinfer_plugin",
-                    f"--ldflags=-L{trt_lib} -Wl,-rpath,{trt_lib} -lnvinfer -lnvonnxparser -lnvinfer_plugin",
-                    "--name",
-                    "torchpipe_tensorrt"
-                ],
-                check=True,
-                env={**os.environ, "EXAMPLE_ENV": "1"},
+    if not is_system_exists_trt() and not can_use_trt_env():
+        trt_inc, trt_lib = get_trt_include_lib_dir()
+        if trt_inc is None:
+            trt_inc, trt_lib = cache_trt_dir()
+        if trt_inc is None:
+            raise RuntimeError(
+                "TensorRT not found. Please specify its location using the "
+                "TENSORRT_INCLUDE and TENSORRT_LIB environment variables, "
+                "or set FORCE_DOWNLOAD_TENSORRT=1 to automatically download."
+            )
+        os.environ["LD_LIBRARY_PATH"] = f"{trt_lib}:" + \
+            os.environ.get("LD_LIBRARY_PATH", "")
+        _build_tensorrt_extension(
+            csrc_dir,
+            include_dirs=[trt_inc],
+            ldflags=[f"-L{trt_lib}", f"-Wl,-rpath,{trt_lib}", "-lnvinfer", "-lnvonnxparser", "-lnvinfer_plugin"],
+            extra_cflags=extra_cflags,
+        )
+    else:
+        trt_inc, trt_lib = get_trt_include_lib_dir()
+        if trt_inc and trt_lib:
+            _build_tensorrt_extension(
+                csrc_dir,
+                include_dirs=[trt_inc],
+                ldflags=[f"-L{trt_lib}", f"-Wl,-rpath,{trt_lib}", "-lnvinfer", "-lnvonnxparser", "-lnvinfer_plugin"],
+                extra_cflags=extra_cflags,
             )
         else:
-            trt_inc, trt_lib = get_trt_include_lib_dir()
-            if trt_inc and trt_lib:
-                subprocess.run(
-                    [
-                        sys.executable,
-                        "-m",
-                        "omniback.utils.build_lib",
-                        "--source-dirs",
-                        os.path.join(csrc_dir, "csrc/tensorrt_torch/"),
-                        "--include-dirs",
-                        os.path.join(csrc_dir, "csrc/"),
-                        secret_key_include_dir,
-                        trt_inc,
-                        "--build-with-cuda",
-                        f"--ldflags=-L{trt_lib} -Wl,-rpath,{trt_lib} -lnvinfer -lnvonnxparser -lnvinfer_plugin",
-                        "--name",
-                        "torchpipe_tensorrt"
-                    ],
-                    check=True,
-                    env={**os.environ, "EXAMPLE_ENV": "1"},
-                )
-            else:
-                subprocess.run(
-                    [
-                        sys.executable,
-                        "-m",
-                        "omniback.utils.build_lib",
-                        "--source-dirs",
-                        os.path.join(csrc_dir, "csrc/tensorrt_torch/"),
-                        "--include-dirs",
-                        os.path.join(csrc_dir, "csrc/"),
-                        secret_key_include_dir,
-                        "--build-with-cuda",
-                        f"--ldflags=-lnvinfer -lnvonnxparser -lnvinfer_plugin",
-                        "--name",
-                        "torchpipe_tensorrt"
-                    ],
-                    check=True,
-                    env={**os.environ, "EXAMPLE_ENV": "1"},
-                )
-    finally:
-        shutil.rmtree(secret_key_temp_dir, ignore_errors=True)
+            _build_tensorrt_extension(
+                csrc_dir,
+                include_dirs=[],
+                ldflags=["-lnvinfer", "-lnvonnxparser", "-lnvinfer_plugin"],
+                extra_cflags=extra_cflags,
+            )

--- a/plugins/torchpipe/torchpipe/utils/encrypt.py
+++ b/plugins/torchpipe/torchpipe/utils/encrypt.py
@@ -1,0 +1,93 @@
+"""Encrypt model files with the TensorRT extension's compile-time key."""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import os
+from pathlib import Path
+
+from omniback.utils import build_lib
+
+from ..load_libs import _load_or_build_lib, get_whl_lib
+
+
+def _resolve_tensorrt_lib_path() -> str:
+    _load_or_build_lib("torchpipe_tensorrt")
+
+    cache_lib = build_lib.get_cache_lib("torchpipe_tensorrt", "cuda", False)
+    if os.path.exists(cache_lib):
+        return cache_lib
+
+    whl_lib = get_whl_lib(cache_lib)
+    if whl_lib and os.path.exists(whl_lib):
+        return whl_lib
+
+    raise RuntimeError("torchpipe_tensorrt library is not available")
+
+
+def _load_encrypt_symbol(lib_path: str):
+    mode = getattr(ctypes, "RTLD_GLOBAL", 0)
+    lib = ctypes.CDLL(lib_path, mode=mode)
+
+    try:
+        return lib.torchpipe_encrypt_file
+    except AttributeError as exc:
+        cache_lib = build_lib.get_cache_lib("torchpipe_tensorrt", "cuda", False)
+        if os.path.exists(cache_lib) and os.path.samefile(lib_path, cache_lib):
+            os.remove(cache_lib)
+            raise RuntimeError(
+                "Detected stale cached torchpipe_tensorrt library without "
+                "`torchpipe_encrypt_file`. Removed cache; please rerun "
+                "`python -m torchpipe.utils.encrypt` to rebuild it."
+            ) from exc
+        raise RuntimeError(
+            f"`torchpipe_encrypt_file` is not exported by {lib_path}. "
+            "Please rebuild torchpipe_tensorrt."
+        ) from exc
+
+
+def encrypt_file(input_path: str, output_path: str) -> None:
+    lib_path = _resolve_tensorrt_lib_path()
+    encrypt = _load_encrypt_symbol(lib_path)
+    encrypt.argtypes = [
+        ctypes.c_char_p,
+        ctypes.c_char_p,
+        ctypes.POINTER(ctypes.c_char),
+        ctypes.c_size_t,
+    ]
+    encrypt.restype = ctypes.c_int
+
+    error_message = ctypes.create_string_buffer(4096)
+    status = encrypt(
+        os.fsencode(input_path),
+        os.fsencode(output_path),
+        error_message,
+        len(error_message),
+    )
+    if status != 0:
+        detail = error_message.value.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(detail or f"encrypt failed with status {status}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Encrypt an ONNX/TRT file with torchpipe TensorRT runtime key.",
+    )
+    parser.add_argument("input", help="Input model path")
+    parser.add_argument("output", help="Output encrypted file path")
+    args = parser.parse_args()
+
+    input_path = Path(args.input).expanduser().resolve()
+    output_path = Path(args.output).expanduser().resolve()
+
+    if not input_path.exists():
+        raise FileNotFoundError(f"input file not found: {input_path}")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    encrypt_file(str(input_path), str(output_path))
+    print(f"Encrypted file written to: {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `python -m torchpipe.utils.encrypt` for generating encrypted ONNX/TRT artifacts
- support loading `.onnx.encrypted` models and `.encrypted` TensorRT cache files in the C++ TensorRT path
- derive the runtime encryption key from `SHA-256(secret)`, generate the compile-time secret in a temporary header, and fix AES block alignment issues
- add focused encryption roundtrip tests

## Testing
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest plugins/torchpipe/tests/test_encrypt_utils.py -q`

## Security Notes
- CodeQL may report clear-text storage for the temporary generated header that defines `SECRET_KEY` during TensorRT JIT build.
- This is a known trade-off of the current compile-time secret design: the secret must be materialized during compilation, and the temporary header is deleted in a `finally` block after build.
- This PR does not claim strong protection against attackers with local filesystem or binary access; the compiled `torchpipe_tensorrt` shared object may still expose the embedded secret to reverse engineering.
- Eliminating this class of findings would require moving from compile-time embedding to runtime secret injection, which is intentionally out of scope for this PR.
